### PR TITLE
fix: pass VITE_* env vars to production UI build

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+env:
+  AWS_REGION: us-east-1
+
 jobs:
   deploy:
     runs-on: ubuntu-latest
@@ -17,11 +20,39 @@ jobs:
           cache: yarn
 
       - run: yarn install --frozen-lockfile
-      - run: yarn deploy
+
+      - name: Deploy auth + API + storage stacks
+        id: api
+        run: |
+          cd packages/infra
+          npx cdk deploy scrappr-auth-dev scrappr-storage-dev scrappr-api-dev \
+            --require-approval never \
+            --outputs-file /tmp/cdk-api-outputs.json 2>&1 | tail -50
+          API_URL=$(node -e "const o=require('/tmp/cdk-api-outputs.json'); console.log(o['scrappr-api-dev'].ApiEndpoint)")
+          echo "api_url=$API_URL" >> $GITHUB_OUTPUT
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
           CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
-          AWS_REGION: us-east-1
+          GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
+          GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}
+
+      - name: Build UI
+        run: yarn workspace @scrappr/ui build
+        env:
+          VITE_USER_POOL_ID: ${{ secrets.VITE_USER_POOL_ID }}
+          VITE_USER_POOL_CLIENT_ID: ${{ secrets.VITE_USER_POOL_CLIENT_ID }}
+          VITE_COGNITO_DOMAIN: ${{ secrets.VITE_COGNITO_DOMAIN }}
+          VITE_API_URL: ${{ steps.api.outputs.api_url }}
+
+      - name: Deploy UI stack
+        run: |
+          cd packages/infra
+          npx cdk deploy scrappr-ui-dev \
+            --require-approval never
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          CDK_DEFAULT_ACCOUNT: ${{ secrets.AWS_ACCOUNT_ID }}
           GOOGLE_CLIENT_ID: ${{ secrets.GOOGLE_CLIENT_ID }}
           GOOGLE_CLIENT_SECRET: ${{ secrets.GOOGLE_CLIENT_SECRET }}


### PR DESCRIPTION
## Root Cause

The `deploy.yml` workflow was missing all `VITE_*` environment variables (`VITE_USER_POOL_ID`, `VITE_USER_POOL_CLIENT_ID`, `VITE_COGNITO_DOMAIN`, `VITE_API_URL`).

When the UI builds without them, Vite replaces them with empty strings. `CognitoUserPool({ UserPoolId: "", ClientId: "" })` then throws at **module load time** (empty string is falsy, SDK throws "Both UserPoolId and ClientId are required"). React never boots → blank white page.

The `pr.yml` preview workflow correctly passes these secrets. `deploy.yml` never did.

## Fix

Split the deploy into three steps (matching the PR preview pattern):
1. Deploy auth/API/storage stacks and capture the API URL from CDK output
2. Build UI with all `VITE_*` secrets + dynamic `VITE_API_URL`  
3. Deploy UI stack with the correctly-built assets

## Testing

- [ ] PR preview deploys correctly with the new flow
- [ ] `scrappr.trevor.fail` renders the app (not blank)