### PR TITLE
fix: add missing format to API Gateway access log settings

### DIFF
--- a/packages/infra/src/stacks/api-stack.ts
+++ b/packages/infra/src/stacks/api-stack.ts
@@ -345,6 +345,16 @@ export class ApiStack extends cdk.Stack {
     const defaultStage = httpApi.defaultStage?.node.defaultChild as apigatewayv2.CfnStage;
     defaultStage.accessLogSettings = {
       destinationArn: accessLogGroup.logGroupArn,
+      format: JSON.stringify({
+        requestId: "$context.requestId",
+        ip: "$context.identity.sourceIp",
+        requestTime: "$context.requestTime",
+        httpMethod: "$context.httpMethod",
+        routeKey: "$context.routeKey",
+        status: "$context.status",
+        protocol: "$context.protocol",
+        responseLength: "$context.responseLength",
+      }),
     };
     defaultStage.defaultRouteSettings = {
       throttlingBurstLimit: 100,


### PR DESCRIPTION
## Problem

The `Deploy Production` workflow on main is failing because the API Gateway access log settings are missing the required `format` field. The CDK deploy rolls back with:

```
Access Log value missing. Expected destinationArn and format.
```

Introduced in commit 2fe3fa9 (feat: enable API Gateway access logging) — it set `destinationArn` but omitted `format`.

## Fix

Adds a JSON format string with standard API Gateway context variables (requestId, IP, method, route, status, etc.).

## Testing

- [ ] CI deploy succeeds (no more rollback on `scrappr-api-dev`)