### PR TITLE
fix: pass VITE_GOOGLE_PLACES_API_KEY to UI build step

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,6 +64,7 @@ jobs:
           VITE_USER_POOL_CLIENT_ID: ${{ secrets.VITE_USER_POOL_CLIENT_ID }}
           VITE_COGNITO_DOMAIN: ${{ secrets.VITE_COGNITO_DOMAIN }}
           VITE_API_URL: ${{ steps.api.outputs.api_url }}
+          VITE_GOOGLE_PLACES_API_KEY: ${{ secrets.VITE_GOOGLE_PLACES_API_KEY }}
 
       - name: Deploy UI stack
         run: |

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -2,9 +2,15 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@vitejs/plugin-react";
 import { defineConfig } from "vite";
 
-export default defineConfig({
-  plugins: [react(), tailwindcss()],
-  define: {
-    global: "globalThis",
-  },
+export default defineConfig(({ command }) => {
+  if (command === "build" && !process.env.VITE_GOOGLE_PLACES_API_KEY) {
+    throw new Error("VITE_GOOGLE_PLACES_API_KEY is required for production builds");
+  }
+
+  return {
+    plugins: [react(), tailwindcss()],
+    define: {
+      global: "globalThis",
+    },
+  };
 });


### PR DESCRIPTION
## Summary

- Adds `VITE_GOOGLE_PLACES_API_KEY` to the **Build UI** step in `deploy.yml` — it was only on the Deploy UI stack step, but Vite inlines env vars at build time so the key was never making it into the bundle
- Adds a build-time guard in `vite.config.ts` that throws immediately if the key is missing during `vite build`

## Test plan

- [ ] Confirm `VITE_GOOGLE_PLACES_API_KEY` is set as a GitHub Actions secret
- [ ] Merge and verify address autocomplete works in production

🤖 Generated with [Claude Code](https://claude.com/claude-code)