### PR TITLE
fix: allow POST in S3 CORS config for presigned multipart uploads

### DIFF
--- a/packages/infra/src/stacks/storage-stack.ts
+++ b/packages/infra/src/stacks/storage-stack.ts
@@ -25,8 +25,8 @@ export class StorageStack extends cdk.Stack {
       blockPublicAccess: s3.BlockPublicAccess.BLOCK_ALL,
       cors: [
         {
-          // PUT only — uploads go directly to S3 via presigned URL; reads go through CloudFront
-          allowedMethods: [s3.HttpMethods.PUT],
+          // POST only — uploads use createPresignedPost (multipart form); reads go through CloudFront
+          allowedMethods: [s3.HttpMethods.POST],
           allowedOrigins: isPreview
             ? ["https://*"]
             : ["http://localhost:5173", "http://localhost:4173", "https://scrappr.trevor.fail"],


### PR DESCRIPTION
## Summary

The security refactor in #183cb8a switched photo uploads from presigned `PUT` to `createPresignedPost` (multipart form `POST`), but the S3 bucket CORS config was never updated to allow `POST` — it only allowed `PUT`. This caused a CORS preflight failure, surfacing as a `NetworkError` when users tried to create or edit a listing.

One-line fix: `PUT` → `POST` in the CORS `allowedMethods`.

## Test plan

- [ ] Create a listing with a photo in production — should succeed without NetworkError
- [ ] Edit a listing photo — should succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)