### PR TITLE
fix: add success feedback after listing creation

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Route, Routes } from "react-router-dom";
 import { Header } from "./components/Header";
+import { Toast } from "./components/Toast";
 import { AuthContext, useCognito } from "./hooks/useAuth";
 import { AuthCallback } from "./pages/AuthCallback";
 import { CreateListing } from "./pages/CreateListing";
@@ -16,6 +17,7 @@ function App() {
     <AuthContext.Provider value={auth}>
       <BrowserRouter>
         <div className="min-h-screen bg-gray-50 flex flex-col">
+          <Toast />
           <Header />
           <main className="flex-1 flex flex-col">
             <Routes>

--- a/packages/ui/src/components/Toast.tsx
+++ b/packages/ui/src/components/Toast.tsx
@@ -1,0 +1,30 @@
+import { CheckCircle2, X, XCircle } from "lucide-react";
+import { useToast } from "../store/useToast";
+
+export function Toast() {
+  const { message, type, dismiss } = useToast();
+
+  if (!message) return null;
+
+  return (
+    <div className="fixed top-4 left-1/2 -translate-x-1/2 z-50 animate-[slideDown_0.3s_ease-out]">
+      <div
+        className={`flex items-center gap-2 px-4 py-3 rounded-xl shadow-lg border text-sm font-medium ${
+          type === "success"
+            ? "bg-emerald-50 border-emerald-200 text-emerald-800"
+            : "bg-red-50 border-red-200 text-red-800"
+        }`}
+      >
+        {type === "success" ? <CheckCircle2 size={18} /> : <XCircle size={18} />}
+        {message}
+        <button
+          type="button"
+          onClick={dismiss}
+          className="ml-2 opacity-60 hover:opacity-100 transition-opacity"
+        >
+          <X size={14} />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/index.css
+++ b/packages/ui/src/index.css
@@ -20,3 +20,14 @@ body {
 .leaflet-popup-content {
   margin: 0 !important;
 }
+
+@keyframes slideDown {
+  from {
+    opacity: 0;
+    transform: translateX(-50%) translateY(-1rem);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(-50%) translateY(0);
+  }
+}

--- a/packages/ui/src/pages/CreateListing.tsx
+++ b/packages/ui/src/pages/CreateListing.tsx
@@ -23,12 +23,14 @@ import {
 
 import { useAuth } from "../hooks/useAuth";
 import { useStore } from "../store/useStore";
+import { useToast } from "../store/useToast";
 
 export function CreateListing() {
   const navigate = useNavigate();
   const { accessToken, isAuthenticated, isLoading: authLoading } = useAuth();
 
   const { addresses, addressesLoaded, setAddresses } = useStore();
+  const toast = useToast();
   const [addressesLoading, setAddressesLoading] = useState(false);
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
 
@@ -134,6 +136,7 @@ export function CreateListing() {
         estimatedValue: catInfo?.payoutLabel || "Varies",
       });
 
+      toast.show("Listing created!");
       navigate("/list");
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Failed to create listing");

--- a/packages/ui/src/store/useToast.ts
+++ b/packages/ui/src/store/useToast.ts
@@ -1,0 +1,18 @@
+import { create } from "zustand";
+
+interface ToastState {
+  message: string | null;
+  type: "success" | "error";
+  show: (message: string, type?: "success" | "error") => void;
+  dismiss: () => void;
+}
+
+export const useToast = create<ToastState>((set) => ({
+  message: null,
+  type: "success",
+  show: (message, type = "success") => {
+    set({ message, type });
+    setTimeout(() => set({ message: null }), 4000);
+  },
+  dismiss: () => set({ message: null }),
+}));


### PR DESCRIPTION
Adds a success toast notification after a listing is successfully created, so users get clear feedback.

## Changes
- New `useToast` zustand store for lightweight global toast state
- New `Toast` component rendered in App.tsx (auto-dismisses after 4s)
- `CreateListing` now shows "Listing created!" toast before navigating to dashboard
- Slide-down animation keyframe added to index.css

Closes #76