### PR TITLE
feat: add visible edit icon button on listing cards

### DIFF
--- a/packages/ui/src/pages/ScrappeeDashboard.tsx
+++ b/packages/ui/src/pages/ScrappeeDashboard.tsx
@@ -1,4 +1,4 @@
-import { Image as ImageIcon, Loader2, LogOut, Plus } from "lucide-react";
+import { Image as ImageIcon, Loader2, LogOut, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getMyListings } from "../api/client";
@@ -209,7 +209,22 @@ function ListingCard({ listing }: { listing: Listing }) {
                 {getCategoryDisplayName(listing.category)}
               </span>
             </div>
-            <StatusBadge status={listing.status} />
+            <div className="flex items-center gap-2">
+              {isEditable && (
+                <button
+                  type="button"
+                  aria-label="Edit listing"
+                  className="p-1.5 rounded-lg text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/list/edit/${listing.id}`);
+                  }}
+                >
+                  <Pencil size={14} />
+                </button>
+              )}
+              <StatusBadge status={listing.status} />
+            </div>
           </div>
           <p className="text-gray-600 text-sm mt-1 line-clamp-2">{listing.description}</p>
           <div className="flex items-center gap-4 mt-2 text-xs text-gray-400">


### PR DESCRIPTION
## Summary

Adds a pencil/edit icon button next to the status badge on editable listing cards in the Scrappee Dashboard.

### Changes
- Imported `Pencil` icon from lucide-react
- Added an edit button (pencil icon) that appears on editable listings (status = `available`)
- Button is positioned next to the `StatusBadge` in the card header
- Click handler navigates to `/list/edit/:id` (same as the card body click)
- Uses `e.stopPropagation()` to avoid double-firing with the card's onClick
- Styled with hover states matching the emerald theme

### Behavior
- Card body click-to-edit is preserved
- Edit icon only shows on editable listings (`available` status)
- Accessible: proper `aria-label` and `button` element

Closes #57