### PR TITLE
fix: add e2e test cleanup to delete listings after each run

### DIFF
--- a/packages/e2e/tests/hauler.spec.ts
+++ b/packages/e2e/tests/hauler.spec.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { ListingTracker } from "./helpers/cleanup.ts";
 
 // Scrappee account — creates listings for pickup
 const SCRAPPEE_EMAIL = "test@scrappr.dev";
@@ -13,7 +14,12 @@ const HAULER_PASSWORD = "TestPass123!";
 // Real address in St. Louis Park, MN (zip 55416) — within Scrappr's service area
 const ADDRESS_QUERY = "5005 Minnetonka Blvd St Louis Park";
 
+const tracker = new ListingTracker();
+
 test("scrappee creates listing, hauler claims and marks picked up", async ({ page }) => {
+  // Install response listener to capture created listing IDs
+  tracker.install(page);
+
   // Unique description so we can reliably find this listing in the hauler view
   const testDescription = `E2E hauler test - aluminum scrap ${Date.now()}`;
 
@@ -64,6 +70,16 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
   await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText(testDescription).first()).toBeVisible({ timeout: 10_000 });
 
+  // Save the scrappee's access token before signing out — needed for cleanup
+  const scrappeeToken = await page.evaluate(() => {
+    for (const key of Object.keys(localStorage)) {
+      if (key.endsWith(".accessToken")) {
+        return localStorage.getItem(key);
+      }
+    }
+    return null;
+  });
+
   // ── Step 2: Sign out ───────────────────────────────────────────────────────
 
   await page.goto("/signed-out");
@@ -112,4 +128,23 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
 
   // Card disappears from active claims (status changes to "completed")
   await expect(claimedCard).not.toBeVisible({ timeout: 10_000 });
+
+  // ── Cleanup: Delete test listings ─────────────────────────────────────────
+
+  const apiUrl = process.env.VITE_API_URL;
+  if (apiUrl && scrappeeToken && tracker.trackedIds.length > 0) {
+    for (const id of tracker.trackedIds) {
+      try {
+        await page.request.delete(`${apiUrl}/listings/${id}`, {
+          headers: {
+            Authorization: `Bearer ${scrappeeToken}`,
+            "Content-Type": "application/json",
+          },
+        });
+      } catch (e) {
+        console.warn(`[e2e cleanup] Failed to delete listing ${id}:`, e);
+      }
+    }
+    console.log(`[e2e cleanup] Deleted ${tracker.trackedIds.length} test listing(s)`);
+  }
 });

--- a/packages/e2e/tests/helpers/cleanup.ts
+++ b/packages/e2e/tests/helpers/cleanup.ts
@@ -1,0 +1,106 @@
+import type { Page } from "@playwright/test";
+
+/**
+ * Tracks listing IDs created during e2e tests and deletes them in teardown.
+ *
+ * Usage:
+ *   const tracker = new ListingTracker();
+ *   await tracker.install(page);         // auto-captures from POST /listings responses
+ *   // ... test creates listings via the UI ...
+ *   await tracker.cleanup(page);         // deletes all tracked listings
+ */
+export class ListingTracker {
+  private listingIds: string[] = [];
+
+  /** Manually record a listing ID for later cleanup. */
+  add(id: string) {
+    this.listingIds.push(id);
+  }
+
+  /**
+   * Install a response listener on `page` that intercepts POST /listings responses
+   * and captures the created listing ID automatically.
+   * Call this BEFORE the test creates a listing.
+   */
+  install(page: Page) {
+    page.on("response", async (response) => {
+      try {
+        const url = response.url();
+        const method = response.request().method();
+        // Match POST to /listings but not sub-routes like /listings/:id/claim
+        if (method === "POST" && /\/listings\/?$/.test(url) && response.ok()) {
+          const body = await response.json();
+          const id = body?.listingId ?? body?.id;
+          if (id) {
+            this.listingIds.push(id);
+          }
+        }
+      } catch {
+        // ignore parse errors on non-JSON responses
+      }
+    });
+  }
+
+  /**
+   * Delete all tracked listings by calling the API directly.
+   * Extracts the access token from the page's JavaScript context.
+   */
+  async cleanup(page: Page) {
+    if (this.listingIds.length === 0) return;
+
+    const apiUrl = process.env.VITE_API_URL;
+    if (!apiUrl) {
+      console.warn("[e2e cleanup] VITE_API_URL not set — skipping cleanup");
+      return;
+    }
+
+    // Extract the Cognito access token from the page's localStorage/sessionStorage
+    const accessToken = await page.evaluate(() => {
+      // Cognito JS SDK stores tokens in localStorage with keys like:
+      // CognitoIdentityServiceProvider.<clientId>.<username>.accessToken
+      for (const key of Object.keys(localStorage)) {
+        if (key.endsWith(".accessToken")) {
+          return localStorage.getItem(key);
+        }
+      }
+      return null;
+    });
+
+    if (!accessToken) {
+      console.warn("[e2e cleanup] Could not extract access token — skipping cleanup");
+      return;
+    }
+
+    const errors: string[] = [];
+    for (const id of this.listingIds) {
+      try {
+        const res = await page.request.delete(`${apiUrl}/listings/${id}`, {
+          headers: {
+            Authorization: `Bearer ${accessToken}`,
+            "Content-Type": "application/json",
+          },
+        });
+        if (!res.ok()) {
+          errors.push(`Failed to delete listing ${id}: ${res.status()}`);
+        }
+      } catch (e) {
+        errors.push(`Failed to delete listing ${id}: ${e}`);
+      }
+    }
+
+    if (errors.length) {
+      console.warn("[e2e cleanup] Some listings could not be deleted:", errors);
+    }
+
+    const cleaned = this.listingIds.length - errors.length;
+    if (cleaned > 0) {
+      console.log(`[e2e cleanup] Deleted ${cleaned} test listing(s)`);
+    }
+
+    this.listingIds = [];
+  }
+
+  get trackedIds(): readonly string[] {
+    return this.listingIds;
+  }
+}

--- a/packages/e2e/tests/listing-creation.spec.ts
+++ b/packages/e2e/tests/listing-creation.spec.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { ListingTracker } from "./helpers/cleanup.ts";
 
 const TEST_EMAIL = "test@scrappr.dev";
 const TEST_PASSWORD = "TestPass123!";
@@ -7,8 +8,12 @@ const TEST_PASSWORD = "TestPass123!";
 // Real address in St. Louis Park, MN (zip 55416) — within Scrappr's service area
 const ADDRESS_QUERY = "5005 Minnetonka Blvd St Louis Park";
 
+const tracker = new ListingTracker();
+
 test.describe("Listing Creation Flow", () => {
   test.beforeEach(async ({ page }) => {
+    tracker.install(page);
+
     await page.goto("/list");
     await expect(page.getByText("Sign In to Scrappr")).toBeVisible();
     await page.getByPlaceholder("you@example.com").fill(TEST_EMAIL);
@@ -16,6 +21,10 @@ test.describe("Listing Creation Flow", () => {
     await page.getByRole("button", { name: "Sign In", exact: true }).click();
     await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
     await expect(page.getByText(`Signed in as ${TEST_EMAIL}`)).toBeVisible();
+  });
+
+  test.afterEach(async ({ page }) => {
+    await tracker.cleanup(page);
   });
 
   test("create listing with photo, see it in My Listings", async ({ page }) => {


### PR DESCRIPTION
## Summary

Fixes #64 — test data accumulation from e2e runs.

### Problem
The `test@scrappr.dev` account accumulates identical test listings from every e2e run with no cleanup mechanism, polluting the dev environment.

### Solution
Added a `ListingTracker` helper class that:

1. **Intercepts** `POST /listings` API responses during tests to automatically capture created listing IDs
2. **Extracts** the Cognito access token from `localStorage` (where the Cognito JS SDK stores it)
3. **Deletes** all tracked listings via `DELETE /listings/:id` API calls in test teardown

### Changes
- `packages/e2e/tests/helpers/cleanup.ts` — new `ListingTracker` utility
- `packages/e2e/tests/listing-creation.spec.ts` — installs tracker in `beforeEach`, cleans up in `afterEach`
- `packages/e2e/tests/hauler.spec.ts` — installs tracker, saves scrappee token before sign-out, cleans up after the full hauler flow

### Notes
- Uses `VITE_API_URL` env var (already available in CI) for API calls
- Cleanup is best-effort: failures are logged as warnings but don't fail the test
- No new dependencies added