### PR TITLE
fix: add EmailStack dependency to AuthStack to fix deploy ordering

### DIFF
--- a/packages/infra/src/app.ts
+++ b/packages/infra/src/app.ts
@@ -74,6 +74,9 @@ if (!sharesDevAuth) {
     senderEmail: emailStack?.senderEmail,
     appUrl,
   });
+  if (emailStack) {
+    authStack.addDependency(emailStack);
+  }
 }
 
 // Storage stack — deploy for all environments


### PR DESCRIPTION
## Summary
- Adds `authStack.addDependency(emailStack)` so CDK deploys EmailStack before AuthStack
- Fixes the deploy failure introduced in #86 where Cognito tried to configure SES sender email before the SES domain identity was created
- `senderEmail` is a plain string (not a CDK token), so CDK had no implicit dependency and deployed both stacks in parallel

## Test plan
- [ ] Deploy succeeds on main (EmailStack completes before AuthStack)
- [ ] SES receipt rule set is activated
- [ ] Existing e2e tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)