### PR TITLE
ci: run unit tests in PR before preview deploy

### DIFF
--- a/.claude/skills/dns/SKILL.md
+++ b/.claude/skills/dns/SKILL.md
@@ -61,17 +61,17 @@ curl -s -X DELETE "https://spaceship.dev/api/v1/dns/records/scrappr.io" \
 
 ## Supported record types
 
-| Type  | Key fields                          |
-|-------|-------------------------------------|
-| A     | `address` (IPv4)                    |
-| AAAA  | `address` (IPv6)                    |
-| CNAME | `cname`                             |
-| MX    | `exchange`, `preference`            |
-| TXT   | `value`                             |
-| NS    | `nameserver`                        |
-| CAA   | `flag`, `tag`, `value`              |
+| Type  | Key fields                                                    |
+| ----- | ------------------------------------------------------------- |
+| A     | `address` (IPv4)                                              |
+| AAAA  | `address` (IPv6)                                              |
+| CNAME | `cname`                                                       |
+| MX    | `exchange`, `preference`                                      |
+| TXT   | `value`                                                       |
+| NS    | `nameserver`                                                  |
+| CAA   | `flag`, `tag`, `value`                                        |
 | SRV   | `service`, `protocol`, `priority`, `weight`, `port`, `target` |
-| ALIAS | `aliasName`                         |
+| ALIAS | `aliasName`                                                   |
 
 ## Rules
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -25,8 +25,22 @@ jobs:
       - run: yarn install --frozen-lockfile
       - run: yarn run check
 
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: yarn
+
+      - run: yarn install --frozen-lockfile
+      - run: yarn test
+
   deploy-preview:
     runs-on: ubuntu-latest
+    needs: test
     permissions:
       pull-requests: write
     outputs:


### PR DESCRIPTION
## Summary
- Adds a `test` job to the PR workflow that runs `yarn test` (node --test on lambda `.test.mjs` files)
- Makes `deploy-preview` depend on `test` so preview deploys are blocked if unit tests fail

## Testing plan
- [x] Verify the new `test` job runs on this PR and passes
- [x] Verify `deploy-preview` only starts after `test` succeeds (check workflow graph in Actions tab)
- [x] Verify the preview URL still gets posted as a PR comment once deploy-preview completes
- [x] Confirm e2e job still runs against the preview as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)