### PR TITLE
fix: set nav z-index above leaflet map panes

### DIFF
--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.LINT_FIX_PAT }}
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/lint-fix.yml
+++ b/.github/workflows/lint-fix.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.LINT_FIX_PAT }}
 
       - uses: actions/setup-node@v4
         with:

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -8,7 +8,7 @@ export function Header() {
   const loginPath = location.pathname === "/" ? "/list" : location.pathname;
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-50">
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-[800]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}

--- a/packages/ui/src/components/Header.tsx
+++ b/packages/ui/src/components/Header.tsx
@@ -8,7 +8,7 @@ export function Header() {
   const loginPath = location.pathname === "/" ? "/list" : location.pathname;
 
   return (
-    <header className="bg-white border-b border-gray-200 sticky top-0 z-[800]">
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-[1001]">
       <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
         <div className="flex items-center justify-between h-16">
           {/* Logo */}


### PR DESCRIPTION
## Problem

On the landing page, the Leaflet map renders on top of the nav bar — the user avatar and "Log In" button are covered by map tiles on mobile/narrow viewports. Leaflet's default map panes use z-indexes ranging from 200–700.

## Fix

Bumped the `<header>` z-index from Tailwind's `z-50` (z-index: 50) to `z-[800]` (z-index: 800), which sits above all Leaflet pane layers.

**File changed:** `packages/ui/src/components/Header.tsx`

Closes #99