### PR TITLE
ci: deploy alert and monitoring stacks to dev (#90)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -47,7 +47,7 @@ jobs:
 
       - name: Wait for any in-progress stack updates
         run: |
-          for STACK in scrappr-email-dev scrappr-auth-dev scrappr-storage-dev scrappr-api-dev scrappr-ui-dev; do
+          for STACK in scrappr-email-dev scrappr-alert-dev scrappr-auth-dev scrappr-storage-dev scrappr-api-dev scrappr-ui-dev scrappr-monitoring-dev; do
             STATUS=$(aws cloudformation describe-stacks --stack-name "$STACK" --query "Stacks[0].StackStatus" --output text 2>/dev/null || echo "DOES_NOT_EXIST")
             if echo "$STATUS" | grep -q "IN_PROGRESS"; then
               echo "Waiting for $STACK ($STATUS)..."
@@ -56,11 +56,17 @@ jobs:
             fi
           done
 
-      - name: Deploy auth + storage + API stacks
+      - name: Deploy email + alert + auth + storage + API + monitoring stacks
         id: api
         run: |
           cd packages/infra
-          npx cdk deploy scrappr-email-dev scrappr-auth-dev scrappr-storage-dev scrappr-api-dev \
+          npx cdk deploy \
+            scrappr-email-dev \
+            scrappr-alert-dev \
+            scrappr-auth-dev \
+            scrappr-storage-dev \
+            scrappr-api-dev \
+            scrappr-monitoring-dev \
             --require-approval never \
             --outputs-file /tmp/cdk-api-outputs.json 2>&1 | tail -50
           API_URL=$(node -e "const o=require('/tmp/cdk-api-outputs.json'); console.log(o['scrappr-api-dev'].ApiEndpoint)")


### PR DESCRIPTION
## Summary

The `AlertStack` and `MonitoringStack` were added in #89 but never wired into the CI deploy list, so they've been synthesized but not deployed. Result: no `scrappr-alerts-dev` SNS topic, no confirmation emails, no alerts. This PR adds both stacks to the deploy workflow.

## Why this went unnoticed

`cdk deploy` only deploys stacks you explicitly name. When AlertStack was added to \`app.ts\`, \`.github/workflows/deploy.yml\` was never updated to include it, so it silently stayed out of deployments.

## Changes

- Added \`scrappr-alert-dev\` and \`scrappr-monitoring-dev\` to the wait-for-in-progress loop so CI doesn't race a prior run
- Added both stacks to the main \`cdk deploy\` command
- Stack order respects the dependency graph:
  - \`email\` → \`alert\` (alert is independent of email at synth; fallback exists in app.ts)
  - \`alert\` → \`api\` (ApiStack consumes \`alertStack.alertTopic\`)
  - \`monitoring\` last (consumes \`alertStack.alertTopic\`)
- Rollback step intentionally **not** updated — rollback only redeploys auth + storage + api, and it's correct to leave the alert topic alone (prevents accidentally recycling SNS subscriptions during rollbacks)

## Test plan

- [ ] PR checks pass (lint, format)
- [ ] After merge to main, Deploy Production workflow runs cleanly
- [ ] \`aws cloudformation describe-stacks --stack-name scrappr-alert-dev\` shows \`CREATE_COMPLETE\`
- [ ] \`trevbot@trevor.fail\` and \`trevorlitsey@gmail.com\` receive AWS SNS subscription confirmation emails
- [ ] Click confirm in both → \`aws sns list-subscriptions-by-topic\` shows both as \`Confirmed\` (not \`PendingConfirmation\`)
- [ ] After confirming, closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)