### PR TITLE
feat: optional phone number sharing on listings

### DIFF
--- a/packages/e2e/tests/hauler.spec.ts
+++ b/packages/e2e/tests/hauler.spec.ts
@@ -59,6 +59,10 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
     await page.getByRole("button", { name: "Done" }).click();
   }
 
+  // Opt in to phone sharing — hauler should see the phone only after claiming.
+  await page.getByTestId("share-phone-checkbox").check();
+  await page.getByTestId("phone-input").fill("(612) 555-0199");
+
   await expect(page.getByTestId("submit-listing-btn")).toBeEnabled({ timeout: 10_000 });
   await page.getByTestId("submit-listing-btn").click();
   await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
@@ -86,6 +90,9 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
   const availableCard = page.getByTestId("available-card").filter({ hasText: testDescription });
   await expect(availableCard).toBeVisible({ timeout: 10_000 });
 
+  // Phone is redacted in browse — it must not appear anywhere on the available card
+  await expect(availableCard.getByText(/555-?0199/)).toHaveCount(0);
+
   // ── Step 4: Claim the listing (2-click confirmation) ──────────────────────
 
   await availableCard.getByTestId("claim-btn").click();
@@ -101,6 +108,12 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
   const claimedCard = page.getByTestId("claimed-card").filter({ hasText: testDescription });
   await expect(claimedCard).toBeVisible({ timeout: 10_000 });
   await expect(claimedCard.getByText("Claimed by you")).toBeVisible();
+
+  // Phone is revealed to the hauler only after claiming
+  const phoneLink = claimedCard.getByTestId("claimed-phone-link");
+  await expect(phoneLink).toBeVisible();
+  await expect(phoneLink).toHaveText("(612) 555-0199");
+  await expect(phoneLink).toHaveAttribute("href", "tel:+16125550199");
 
   // ── Step 6: Mark as picked up (2-click confirmation) ──────────────────────
 

--- a/packages/e2e/tests/listing-creation.spec.ts
+++ b/packages/e2e/tests/listing-creation.spec.ts
@@ -68,6 +68,51 @@ test.describe("Listing Creation Flow", () => {
     await expect(page.getByAltText("copper").first()).toBeVisible();
   });
 
+  test("phone sharing: checkbox gates input, invalid number blocks submit", async ({ page }) => {
+    await page.getByRole("link", { name: "New Listing" }).click();
+    await expect(page.getByText("Create a New Scrap Metal Listing")).toBeVisible();
+
+    // Phone input is hidden until the checkbox is ticked
+    await expect(page.getByTestId("phone-input")).not.toBeVisible();
+
+    const shareCheckbox = page.getByTestId("share-phone-checkbox");
+    await shareCheckbox.check();
+    await expect(page.getByTestId("phone-input")).toBeVisible();
+
+    // Fill in required fields so the only thing blocking submit is the phone
+    const fileInput = page.getByTestId("photo-input");
+    const testPhotoPath = path.join(import.meta.dirname, "../fixtures/test-photo.jpg");
+    await fileInput.setInputFiles(testPhotoPath);
+    await page.getByTestId("category-copper").click();
+    await page.getByTestId("description-input").fill("phone validation test");
+
+    // Address — add if none saved, otherwise auto-selected by AddressPicker
+    await expect(
+      page.getByRole("button", { name: "Add a pickup address" }).or(page.getByRole("combobox")),
+    ).toBeVisible({ timeout: 10_000 });
+    if (await page.getByRole("button", { name: "Add a pickup address" }).isVisible()) {
+      await page.getByRole("button", { name: "Add a pickup address" }).click();
+      await page.getByTestId("address-input").fill(ADDRESS_QUERY);
+      await expect(page.getByTestId("address-suggestion").first()).toBeVisible({ timeout: 15_000 });
+      await page.getByTestId("address-suggestion").first().click();
+      await page.getByRole("button", { name: "Save" }).click();
+      await page.getByRole("button", { name: "Done" }).click();
+    }
+
+    // Invalid phone → submit disabled
+    await page.getByTestId("phone-input").fill("123");
+    await expect(page.getByTestId("submit-listing-btn")).toBeDisabled();
+
+    // Valid phone → submit enabled
+    await page.getByTestId("phone-input").fill("(612) 555-0199");
+    await expect(page.getByTestId("submit-listing-btn")).toBeEnabled({ timeout: 5_000 });
+
+    // Unchecking the box clears the validation block even if phone is empty
+    await shareCheckbox.uncheck();
+    await expect(page.getByTestId("phone-input")).not.toBeVisible();
+    await expect(page.getByTestId("submit-listing-btn")).toBeEnabled();
+  });
+
   test("drag-and-drop photo upload shows preview", async ({ page }) => {
     // 1. Navigate to New Listing page
     await page.getByRole("link", { name: "New Listing" }).click();

--- a/packages/infra/src/lambdas/create-listing.mjs
+++ b/packages/infra/src/lambdas/create-listing.mjs
@@ -7,7 +7,18 @@ const TABLE = process.env.LISTINGS_TABLE;
 
 export const handler = withAuth(async (event, { userId }) => {
   const body = JSON.parse(event.body || "{}");
-  const { category, description, photoUrl, lat, lng, address, zipCode, estimatedValue } = body;
+  const {
+    category,
+    description,
+    photoUrl,
+    lat,
+    lng,
+    address,
+    zipCode,
+    estimatedValue,
+    sharePhone,
+    phone,
+  } = body;
 
   if (!category || !description) {
     return json(400, { error: "category and description are required" });
@@ -33,6 +44,8 @@ export const handler = withAuth(async (event, { userId }) => {
       datePosted: new Date().toISOString().split("T")[0],
       estimatedValue: estimatedValue || "Varies",
       createdAt: new Date().toISOString(),
+      sharePhone: Boolean(sharePhone),
+      phone: sharePhone ? phone || "" : "",
     });
   } catch (err) {
     return json(400, { error: err.message });

--- a/packages/infra/src/lambdas/get-listings.mjs
+++ b/packages/infra/src/lambdas/get-listings.mjs
@@ -41,7 +41,9 @@ export const handler = async (event) => {
 
     const result = await ddb.send(new QueryCommand(queryParams));
 
-    const listings = (result.Items || []).map(({ userId: _ownerId, ...item }) => ({
+    // Strip `userId` and `phone` — both are revealed only after the hauler claims.
+    // `sharePhone` is kept so the UI can (optionally) hint that a phone is available.
+    const listings = (result.Items || []).map(({ userId: _ownerId, phone: _phone, ...item }) => ({
       ...item,
       address: redactAddress(item.address),
     }));

--- a/packages/infra/src/lambdas/get-profile.mjs
+++ b/packages/infra/src/lambdas/get-profile.mjs
@@ -1,0 +1,16 @@
+import { GetCommand } from "@aws-sdk/lib-dynamodb";
+import { ddb, json, withAuth } from "./lambda-utils.mjs";
+
+const TABLE = process.env.USER_PROFILES_TABLE;
+
+export const handler = withAuth(async (_event, { userId }) => {
+  const result = await ddb.send(
+    new GetCommand({
+      TableName: TABLE,
+      Key: { userId },
+    }),
+  );
+
+  // If no profile yet, return an empty one — the client just needs a phone field.
+  return json(200, { profile: result.Item || { userId } });
+});

--- a/packages/infra/src/lambdas/phone.d.mts
+++ b/packages/infra/src/lambdas/phone.d.mts
@@ -1,0 +1,8 @@
+/** Returns true if the input can be normalized to a valid 10-digit US phone. */
+export function isValidPhone(phone: string): boolean;
+
+/** Normalize any supported US format to E.164 `+1XXXXXXXXXX`. Throws if invalid. */
+export function normalizePhone(phone: string): string;
+
+/** Format E.164 `+1XXXXXXXXXX` as `(XXX) XXX-XXXX` for display. */
+export function formatPhoneForDisplay(phone: string): string;

--- a/packages/infra/src/lambdas/phone.mjs
+++ b/packages/infra/src/lambdas/phone.mjs
@@ -1,0 +1,49 @@
+// Canonical phone number validation + normalization.
+//
+// This module is the single source of truth for phone handling across the
+// whole codebase. It lives inside packages/infra/src/lambdas/ so it can be
+// shipped as-is by `lambda.Code.fromAsset`, and is re-exported from
+// packages/shared/src/types.ts for the UI.
+//
+// Keep as plain ESM JS (no TypeScript) so it runs in Node 20 without a build
+// step. Type information comes from the sibling phone.d.mts.
+
+/**
+ * Returns true if the input can be normalized to a valid 10-digit US phone.
+ * @param {string} phone
+ * @returns {boolean}
+ */
+export function isValidPhone(phone) {
+  if (!phone) return false;
+  const digits = String(phone).replace(/\D/g, "");
+  if (digits.length === 10) return true;
+  if (digits.length === 11 && digits.startsWith("1")) return true;
+  return false;
+}
+
+/**
+ * Normalize any supported US format to E.164 `+1XXXXXXXXXX`. Throws if invalid.
+ * @param {string} phone
+ * @returns {string}
+ */
+export function normalizePhone(phone) {
+  if (!phone) throw new Error("Invalid phone number");
+  const digits = String(phone).replace(/\D/g, "");
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  throw new Error("Invalid phone number");
+}
+
+/**
+ * Format E.164 `+1XXXXXXXXXX` as `(XXX) XXX-XXXX` for display.
+ * Returns the input unchanged if it can't be parsed.
+ * @param {string} phone
+ * @returns {string}
+ */
+export function formatPhoneForDisplay(phone) {
+  if (!phone) return "";
+  const digits = String(phone).replace(/\D/g, "");
+  const ten = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
+  if (ten.length !== 10) return phone;
+  return `(${ten.slice(0, 3)}) ${ten.slice(3, 6)}-${ten.slice(6)}`;
+}

--- a/packages/infra/src/lambdas/sanitize.mjs
+++ b/packages/infra/src/lambdas/sanitize.mjs
@@ -22,10 +22,36 @@ function sanitizePhotoUrl(url) {
 
 const DESCRIPTION_MAX_LENGTH = 1000;
 
+/**
+ * Normalize a US phone number to E.164 `+1XXXXXXXXXX`. Throws on invalid input.
+ * Mirror of `normalizePhone` in packages/shared/src/types.ts — keep in sync.
+ */
+export function sanitizePhone(phone) {
+  if (!phone) return "";
+  const digits = String(phone).replace(/\D/g, "");
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  throw new Error("Invalid phone number");
+}
+
 /** Sanitize user-provided listing fields before writing to the database. */
-export function sanitizeListing({ category, description, address, photoUrl, ...rest }) {
+export function sanitizeListing({
+  category,
+  description,
+  address,
+  photoUrl,
+  phone,
+  sharePhone,
+  ...rest
+}) {
   if (description !== undefined && typeof description === "string" && description.length > DESCRIPTION_MAX_LENGTH) {
     throw new Error(`Description must be ${DESCRIPTION_MAX_LENGTH} characters or fewer`);
+  }
+
+  // If user opted out, force phone to empty regardless of what was sent.
+  let normalizedPhone;
+  if (phone !== undefined) {
+    normalizedPhone = sharePhone === false ? "" : sanitizePhone(phone);
   }
 
   return {
@@ -34,5 +60,7 @@ export function sanitizeListing({ category, description, address, photoUrl, ...r
     ...(description !== undefined && { description: escapeHtml(description) }),
     ...(address !== undefined && { address: escapeHtml(address) }),
     ...(photoUrl !== undefined && { photoUrl: sanitizePhotoUrl(photoUrl) }),
+    ...(sharePhone !== undefined && { sharePhone: Boolean(sharePhone) }),
+    ...(normalizedPhone !== undefined && { phone: normalizedPhone }),
   };
 }

--- a/packages/infra/src/lambdas/sanitize.mjs
+++ b/packages/infra/src/lambdas/sanitize.mjs
@@ -1,3 +1,5 @@
+import { normalizePhone } from "./phone.mjs";
+
 /** Escape HTML special characters to prevent XSS when user input is rendered. */
 export function escapeHtml(str) {
   if (!str) return "";
@@ -24,14 +26,12 @@ const DESCRIPTION_MAX_LENGTH = 1000;
 
 /**
  * Normalize a US phone number to E.164 `+1XXXXXXXXXX`. Throws on invalid input.
- * Mirror of `normalizePhone` in packages/shared/src/types.ts — keep in sync.
+ * Thin wrapper over the canonical implementation in ./phone.mjs that treats
+ * an empty string as "no phone" rather than an error.
  */
 export function sanitizePhone(phone) {
   if (!phone) return "";
-  const digits = String(phone).replace(/\D/g, "");
-  if (digits.length === 10) return `+1${digits}`;
-  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
-  throw new Error("Invalid phone number");
+  return normalizePhone(phone);
 }
 
 /** Sanitize user-provided listing fields before writing to the database. */

--- a/packages/infra/src/lambdas/update-listing.mjs
+++ b/packages/infra/src/lambdas/update-listing.mjs
@@ -4,7 +4,18 @@ import { ddb, json, withAuth, buildUpdateExpression, validateZip } from "./lambd
 
 const TABLE = process.env.LISTINGS_TABLE;
 
-const ALLOWED_FIELDS = ["category", "description", "photoUrl", "lat", "lng", "address", "zipCode", "estimatedValue"];
+const ALLOWED_FIELDS = [
+  "category",
+  "description",
+  "photoUrl",
+  "lat",
+  "lng",
+  "address",
+  "zipCode",
+  "estimatedValue",
+  "sharePhone",
+  "phone",
+];
 
 export const handler = withAuth("listingId", async (event, { userId, listingId }) => {
   const body = JSON.parse(event.body || "{}");
@@ -14,6 +25,11 @@ export const handler = withAuth("listingId", async (event, { userId, listingId }
     if (body[field] !== undefined) {
       raw[field] = body[field];
     }
+  }
+  // If the user is toggling phone sharing off, clear the stored phone server-side
+  // even if the client didn't include `phone` in the patch body.
+  if (raw.sharePhone === false) {
+    raw.phone = "";
   }
   let updates;
   try {

--- a/packages/infra/src/lambdas/update-profile.mjs
+++ b/packages/infra/src/lambdas/update-profile.mjs
@@ -1,0 +1,29 @@
+import { PutCommand } from "@aws-sdk/lib-dynamodb";
+import { ddb, json, withAuth } from "./lambda-utils.mjs";
+import { sanitizePhone } from "./sanitize.mjs";
+
+const TABLE = process.env.USER_PROFILES_TABLE;
+
+export const handler = withAuth(async (event, { userId }) => {
+  const body = JSON.parse(event.body || "{}");
+  const { phone } = body;
+
+  let normalizedPhone = "";
+  if (phone) {
+    try {
+      normalizedPhone = sanitizePhone(phone);
+    } catch (err) {
+      return json(400, { error: err.message });
+    }
+  }
+
+  const item = {
+    userId,
+    phone: normalizedPhone,
+    updatedAt: new Date().toISOString(),
+  };
+
+  await ddb.send(new PutCommand({ TableName: TABLE, Item: item }));
+
+  return json(200, { profile: item });
+});

--- a/packages/infra/src/stacks/api-stack.ts
+++ b/packages/infra/src/stacks/api-stack.ts
@@ -126,6 +126,14 @@ export class ApiStack extends cdk.Stack {
       removalPolicy: stageName === "prod" ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
     });
 
+    // One row per user — holds a default phone to auto-fill on listing creation.
+    const userProfilesTable = new dynamodb.Table(this, "UserProfilesTable", {
+      tableName: `scrappr-user-profiles-${stageName}`,
+      partitionKey: { name: "userId", type: dynamodb.AttributeType.STRING },
+      billingMode: dynamodb.BillingMode.PAY_PER_REQUEST,
+      removalPolicy: stageName === "prod" ? cdk.RemovalPolicy.RETAIN : cdk.RemovalPolicy.DESTROY,
+    });
+
     listingsTable.addGlobalSecondaryIndex({
       indexName: "status-index",
       partitionKey: { name: "status", type: dynamodb.AttributeType.STRING },
@@ -305,6 +313,18 @@ export class ApiStack extends cdk.Stack {
     });
     addressesTable.grantReadWriteData(deleteAddressFn);
 
+    const getProfileFn = this.createLambda("GetProfile", {
+      handler: "get-profile.handler",
+      environment: { USER_PROFILES_TABLE: userProfilesTable.tableName },
+    });
+    userProfilesTable.grantReadData(getProfileFn);
+
+    const updateProfileFn = this.createLambda("UpdateProfile", {
+      handler: "update-profile.handler",
+      environment: { USER_PROFILES_TABLE: userProfilesTable.tableName },
+    });
+    userProfilesTable.grantReadWriteData(updateProfileFn);
+
     const reportErrorFn = this.createLambda("ReportError", {
       handler: "report-error.handler",
     });
@@ -463,6 +483,20 @@ export class ApiStack extends cdk.Stack {
       path: "/addresses/{addressId}",
       methods: [apigatewayv2.HttpMethod.DELETE],
       integration: new integrations.HttpLambdaIntegration("DeleteAddressInt", deleteAddressFn),
+      authorizer: jwtAuthorizer,
+    });
+
+    httpApi.addRoutes({
+      path: "/profile",
+      methods: [apigatewayv2.HttpMethod.GET],
+      integration: new integrations.HttpLambdaIntegration("GetProfileInt", getProfileFn),
+      authorizer: jwtAuthorizer,
+    });
+
+    httpApi.addRoutes({
+      path: "/profile",
+      methods: [apigatewayv2.HttpMethod.PATCH],
+      integration: new integrations.HttpLambdaIntegration("UpdateProfileInt", updateProfileFn),
       authorizer: jwtAuthorizer,
     });
 

--- a/packages/infra/src/stacks/api-stack.ts
+++ b/packages/infra/src/stacks/api-stack.ts
@@ -495,7 +495,7 @@ export class ApiStack extends cdk.Stack {
 
     httpApi.addRoutes({
       path: "/profile",
-      methods: [apigatewayv2.HttpMethod.PATCH],
+      methods: [apigatewayv2.HttpMethod.POST],
       integration: new integrations.HttpLambdaIntegration("UpdateProfileInt", updateProfileFn),
       authorizer: jwtAuthorizer,
     });

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -19,34 +19,15 @@ export function isAllowedZip(zip: string): boolean {
 }
 
 // ── Phone numbers ────────────────────────────────────────────────────────
-// Stored as E.164 (+1XXXXXXXXXX). US-only for MVP — mirror this logic in
-// packages/infra/src/lambdas/sanitize.mjs (sanitizePhone).
-
-/** Returns true if the input can be normalized to a valid 10-digit US phone. */
-export function isValidPhone(phone: string): boolean {
-  if (!phone) return false;
-  const digits = phone.replace(/\D/g, "");
-  if (digits.length === 10) return true;
-  if (digits.length === 11 && digits.startsWith("1")) return true;
-  return false;
-}
-
-/** Normalize any supported US format to E.164 `+1XXXXXXXXXX`. Throws if invalid. */
-export function normalizePhone(phone: string): string {
-  const digits = phone.replace(/\D/g, "");
-  if (digits.length === 10) return `+1${digits}`;
-  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
-  throw new Error("Invalid phone number");
-}
-
-/** Format E.164 `+1XXXXXXXXXX` as `(XXX) XXX-XXXX` for display. */
-export function formatPhoneForDisplay(phone: string): string {
-  if (!phone) return "";
-  const digits = phone.replace(/\D/g, "");
-  const ten = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
-  if (ten.length !== 10) return phone;
-  return `(${ten.slice(0, 3)}) ${ten.slice(3, 6)}-${ten.slice(6)}`;
-}
+// The canonical implementation lives in packages/infra/src/lambdas/phone.mjs
+// so it can be shipped as-is by `lambda.Code.fromAsset`. We re-export it here
+// so UI code can import from `@scrappr/shared/src/types` as before.
+// Stored as E.164 (+1XXXXXXXXXX). US-only for MVP.
+export {
+  formatPhoneForDisplay,
+  isValidPhone,
+  normalizePhone,
+} from "../../infra/src/lambdas/phone.mjs";
 
 // ── Categories ──────────────────────────────────────────────────────────
 

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -18,6 +18,36 @@ export function isAllowedZip(zip: string): boolean {
   return ALLOWED_ZIPS.includes(zip.trim());
 }
 
+// ── Phone numbers ────────────────────────────────────────────────────────
+// Stored as E.164 (+1XXXXXXXXXX). US-only for MVP — mirror this logic in
+// packages/infra/src/lambdas/sanitize.mjs (sanitizePhone).
+
+/** Returns true if the input can be normalized to a valid 10-digit US phone. */
+export function isValidPhone(phone: string): boolean {
+  if (!phone) return false;
+  const digits = phone.replace(/\D/g, "");
+  if (digits.length === 10) return true;
+  if (digits.length === 11 && digits.startsWith("1")) return true;
+  return false;
+}
+
+/** Normalize any supported US format to E.164 `+1XXXXXXXXXX`. Throws if invalid. */
+export function normalizePhone(phone: string): string {
+  const digits = phone.replace(/\D/g, "");
+  if (digits.length === 10) return `+1${digits}`;
+  if (digits.length === 11 && digits.startsWith("1")) return `+${digits}`;
+  throw new Error("Invalid phone number");
+}
+
+/** Format E.164 `+1XXXXXXXXXX` as `(XXX) XXX-XXXX` for display. */
+export function formatPhoneForDisplay(phone: string): string {
+  if (!phone) return "";
+  const digits = phone.replace(/\D/g, "");
+  const ten = digits.length === 11 && digits.startsWith("1") ? digits.slice(1) : digits;
+  if (ten.length !== 10) return phone;
+  return `(${ten.slice(0, 3)}) ${ten.slice(3, 6)}-${ten.slice(6)}`;
+}
+
 // ── Categories ──────────────────────────────────────────────────────────
 
 export type Category =
@@ -80,4 +110,22 @@ export interface Listing {
   claimedBy?: string;
   claimedAt?: string;
   estimatedValue: string;
+  /** Opt-in flag persisted on the listing so re-edit shows the correct state. */
+  sharePhone?: boolean;
+  /** E.164 `+1XXXXXXXXXX`. Redacted from public browse; revealed to the hauler after claim. */
+  phone?: string;
+}
+
+// ── User profile ────────────────────────────────────────────────────────
+
+/**
+ * Lightweight per-user profile for data that doesn't belong on a listing.
+ * Currently just holds an optional default phone number to auto-fill on new
+ * listings when the user opts in to phone sharing.
+ */
+export interface UserProfile {
+  userId: string;
+  /** Default phone stored as E.164. Used to auto-fill the listing form. */
+  phone?: string;
+  updatedAt?: string;
 }

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -1,4 +1,4 @@
-import type { Address, Listing } from "../data/types";
+import type { Address, Listing, UserProfile } from "../data/types";
 
 const API_URL = import.meta.env.VITE_API_URL;
 
@@ -53,6 +53,8 @@ interface CreateListingPayload {
   address: string;
   zipCode: string;
   estimatedValue: string;
+  sharePhone?: boolean;
+  phone?: string;
 }
 
 export async function createListing(
@@ -76,6 +78,8 @@ interface UpdateListingPayload {
   address?: string;
   zipCode?: string;
   estimatedValue?: string;
+  sharePhone?: boolean;
+  phone?: string;
 }
 
 export async function updateListing(
@@ -213,6 +217,29 @@ export async function unclaimListing(accessToken: string, listingId: string): Pr
 export async function getClaimedListings(accessToken: string): Promise<{ listings: Listing[] }> {
   const res = await apiRequest("/listings/claimed", accessToken);
   if (!res.ok) throw new Error("Failed to fetch claimed listings");
+  return res.json();
+}
+
+// ── User profile ─────────────────────────────────────────────────────────
+
+export async function getProfile(accessToken: string): Promise<{ profile: UserProfile }> {
+  const res = await apiRequest("/profile", accessToken);
+  if (!res.ok) throw new Error("Failed to fetch profile");
+  return res.json();
+}
+
+export async function updateProfile(
+  accessToken: string,
+  payload: { phone?: string },
+): Promise<{ profile: UserProfile }> {
+  const res = await apiRequest("/profile", accessToken, {
+    method: "PATCH",
+    body: JSON.stringify(payload),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error((data as { error?: string }).error || "Failed to update profile");
+  }
   return res.json();
 }
 

--- a/packages/ui/src/api/client.ts
+++ b/packages/ui/src/api/client.ts
@@ -233,7 +233,7 @@ export async function updateProfile(
   payload: { phone?: string },
 ): Promise<{ profile: UserProfile }> {
   const res = await apiRequest("/profile", accessToken, {
-    method: "PATCH",
+    method: "POST",
     body: JSON.stringify(payload),
   });
   if (!res.ok) {

--- a/packages/ui/src/components/PhoneSharingField.tsx
+++ b/packages/ui/src/components/PhoneSharingField.tsx
@@ -1,0 +1,61 @@
+interface PhoneSharingFieldProps {
+  sharePhone: boolean;
+  phone: string;
+  invalid: boolean;
+  showError: boolean;
+  onShareChange: (value: boolean) => void;
+  onPhoneChange: (value: string) => void;
+}
+
+/**
+ * Opt-in checkbox + conditional phone input shared between CreateListing and
+ * EditListing. The phone is only revealed to the hauler after they claim the
+ * listing — mirrors the address privacy pattern.
+ */
+export function PhoneSharingField({
+  sharePhone,
+  phone,
+  invalid,
+  showError,
+  onShareChange,
+  onPhoneChange,
+}: PhoneSharingFieldProps) {
+  return (
+    <div>
+      <label className="flex items-start gap-2 cursor-pointer">
+        <input
+          type="checkbox"
+          checked={sharePhone}
+          onChange={(e) => onShareChange(e.target.checked)}
+          className="mt-1 h-4 w-4 rounded border-gray-300 text-emerald-600 focus:ring-emerald-500"
+          data-testid="share-phone-checkbox"
+        />
+        <span className="text-sm">
+          <span className="font-medium text-gray-700">Share my phone number with the hauler</span>
+          <span className="block text-xs text-gray-500 mt-0.5">
+            Your phone stays private until someone claims this listing — just like your address.
+          </span>
+        </span>
+      </label>
+      {sharePhone && (
+        <div className="mt-3">
+          <input
+            type="tel"
+            inputMode="tel"
+            autoComplete="tel"
+            value={phone}
+            onChange={(e) => onPhoneChange(e.target.value)}
+            placeholder="(612) 555-1234"
+            className={`w-full rounded-xl border px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500 focus:border-transparent ${
+              showError && invalid ? "border-red-300" : "border-gray-300"
+            }`}
+            data-testid="phone-input"
+          />
+          {showError && invalid && (
+            <p className="text-xs text-red-600 mt-1">Enter a valid 10-digit US phone number.</p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/ui/src/data/types.ts
+++ b/packages/ui/src/data/types.ts
@@ -11,7 +11,6 @@ export {
   isValidPhone,
   type Listing,
   type ListingStatus,
-  normalizePhone,
   type UserProfile,
   UserRole,
 } from "@scrappr/shared/src/types";

--- a/packages/ui/src/data/types.ts
+++ b/packages/ui/src/data/types.ts
@@ -6,8 +6,12 @@ export {
   type BlockedCategory,
   type Category,
   type CategoryInfo,
+  formatPhoneForDisplay,
   isAllowedZip,
+  isValidPhone,
   type Listing,
   type ListingStatus,
+  normalizePhone,
+  type UserProfile,
   UserRole,
 } from "@scrappr/shared/src/types";

--- a/packages/ui/src/hooks/useLoadProfile.ts
+++ b/packages/ui/src/hooks/useLoadProfile.ts
@@ -1,0 +1,20 @@
+import { useEffect, useState } from "react";
+import { getProfile } from "../api/client";
+import { useStore } from "../store/useStore";
+
+export function useLoadProfile(accessToken: string | null) {
+  const { profile, profileLoaded, setProfile } = useStore();
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (profileLoaded || !accessToken) return;
+    setLoading(true);
+    getProfile(accessToken)
+      .then((data) => {
+        setProfile(data.profile);
+      })
+      .finally(() => setLoading(false));
+  }, [accessToken, profileLoaded, setProfile]);
+
+  return { profile, loading };
+}

--- a/packages/ui/src/pages/CreateListing.tsx
+++ b/packages/ui/src/pages/CreateListing.tsx
@@ -15,7 +15,6 @@ import {
   formatPhoneForDisplay,
   isAllowedZip,
   isValidPhone,
-  normalizePhone,
 } from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { useLoadAddresses } from "../hooks/useLoadAddresses";
@@ -100,7 +99,7 @@ export function CreateListing() {
       await uploadPhoto(presign.uploadUrl, photoFile, presign.fields);
 
       const catInfo = CATEGORIES.find((c) => c.name === category);
-      const normalizedPhone = sharePhone && phone ? normalizePhone(phone) : "";
+      const phoneToSend = sharePhone ? phone : "";
 
       await createListing(accessToken, {
         category: category as string,
@@ -112,13 +111,14 @@ export function CreateListing() {
         zipCode: zipCode.trim(),
         estimatedValue: catInfo?.payoutLabel || "Varies",
         sharePhone,
-        phone: normalizedPhone,
+        phone: phoneToSend,
       });
 
       // Save phone to the user profile so future listings auto-fill it.
-      if (sharePhone && normalizedPhone && normalizedPhone !== profile?.phone) {
+      // Backend normalizes — compare in local state below by using the response.
+      if (sharePhone && phoneToSend) {
         try {
-          const res = await updateProfile(accessToken, { phone: normalizedPhone });
+          const res = await updateProfile(accessToken, { phone: phoneToSend });
           setProfile(res.profile);
         } catch {
           // Non-fatal — the listing was created successfully.

--- a/packages/ui/src/pages/CreateListing.tsx
+++ b/packages/ui/src/pages/CreateListing.tsx
@@ -1,21 +1,34 @@
 import { DESCRIPTION_MAX_LENGTH } from "@scrappr/shared/src/constants";
 import { AlertTriangle, ArrowLeft, Loader2, MapPin } from "lucide-react";
-import { useCallback, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
-import { createListing, getPresignedUrl, uploadPhoto } from "../api/client";
+import { createListing, getPresignedUrl, updateProfile, uploadPhoto } from "../api/client";
 import { AddressPicker } from "../components/AddressPicker";
 import { CategorySelector } from "../components/CategorySelector";
+import { PhoneSharingField } from "../components/PhoneSharingField";
 import { PhotoUpload } from "../components/PhotoUpload";
 import { CATEGORIES } from "../data/mockData";
-import { type Address, ALLOWED_AREA_LABEL, type Category, isAllowedZip } from "../data/types";
+import {
+  type Address,
+  ALLOWED_AREA_LABEL,
+  type Category,
+  formatPhoneForDisplay,
+  isAllowedZip,
+  isValidPhone,
+  normalizePhone,
+} from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { useLoadAddresses } from "../hooks/useLoadAddresses";
+import { useLoadProfile } from "../hooks/useLoadProfile";
+import { useStore } from "../store/useStore";
 
 export function CreateListing() {
   const navigate = useNavigate();
   const { accessToken } = useAuth();
 
   const { addresses, loading: addressesLoading } = useLoadAddresses(accessToken);
+  const { profile } = useLoadProfile(accessToken);
+  const setProfile = useStore((s) => s.setProfile);
   const [selectedAddressId, setSelectedAddressId] = useState<string | null>(null);
 
   const [category, setCategory] = useState<Category | "">("");
@@ -30,6 +43,18 @@ export function CreateListing() {
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [photoError, setPhotoError] = useState(false);
   const [attempted, setAttempted] = useState(false);
+  const [sharePhone, setSharePhone] = useState(false);
+  const [phone, setPhone] = useState("");
+  const [phoneTouched, setPhoneTouched] = useState(false);
+
+  // Auto-fill phone and opt-in state from the user's saved profile.
+  useEffect(() => {
+    if (!profile?.phone || phoneTouched) return;
+    setPhone(formatPhoneForDisplay(profile.phone));
+    setSharePhone(true);
+  }, [profile, phoneTouched]);
+
+  const phoneInvalid = sharePhone && !isValidPhone(phone);
 
   const validateZip = useCallback((zip: string) => {
     if (zip && !isAllowedZip(zip)) {
@@ -66,6 +91,7 @@ export function CreateListing() {
     }
     if (!photoFile || !category || !description || !address || !zipCode || !isAllowedZip(zipCode))
       return;
+    if (phoneInvalid) return;
     setSubmitting(true);
     setSubmitError(null);
 
@@ -74,6 +100,7 @@ export function CreateListing() {
       await uploadPhoto(presign.uploadUrl, photoFile, presign.fields);
 
       const catInfo = CATEGORIES.find((c) => c.name === category);
+      const normalizedPhone = sharePhone && phone ? normalizePhone(phone) : "";
 
       await createListing(accessToken, {
         category: category as string,
@@ -84,7 +111,19 @@ export function CreateListing() {
         address,
         zipCode: zipCode.trim(),
         estimatedValue: catInfo?.payoutLabel || "Varies",
+        sharePhone,
+        phone: normalizedPhone,
       });
+
+      // Save phone to the user profile so future listings auto-fill it.
+      if (sharePhone && normalizedPhone && normalizedPhone !== profile?.phone) {
+        try {
+          const res = await updateProfile(accessToken, { phone: normalizedPhone });
+          setProfile(res.profile);
+        } catch {
+          // Non-fatal — the listing was created successfully.
+        }
+      }
 
       navigate("/list");
     } catch (err) {
@@ -183,6 +222,21 @@ export function CreateListing() {
             />
           </div>
 
+          <PhoneSharingField
+            sharePhone={sharePhone}
+            phone={phone}
+            invalid={phoneInvalid}
+            showError={attempted}
+            onShareChange={(value) => {
+              setSharePhone(value);
+              setPhoneTouched(true);
+            }}
+            onPhoneChange={(value) => {
+              setPhone(value);
+              setPhoneTouched(true);
+            }}
+          />
+
           {zipError && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-xl flex items-start gap-2">
               <AlertTriangle size={16} className="text-red-500 flex-shrink-0 mt-0.5" />
@@ -220,6 +274,7 @@ export function CreateListing() {
               !address ||
               !zipCode ||
               !!zipError ||
+              phoneInvalid ||
               submitting
             }
             className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40 disabled:cursor-not-allowed shadow-md"

--- a/packages/ui/src/pages/EditListing.tsx
+++ b/packages/ui/src/pages/EditListing.tsx
@@ -7,21 +7,27 @@ import {
   getMyListings,
   getPresignedUrl,
   updateListing,
+  updateProfile,
   uploadPhoto,
 } from "../api/client";
 import { AddressPicker } from "../components/AddressPicker";
 import { CategorySelector } from "../components/CategorySelector";
+import { PhoneSharingField } from "../components/PhoneSharingField";
 import { PhotoUpload } from "../components/PhotoUpload";
 import { CATEGORIES } from "../data/mockData";
 import {
   type Address,
   ALLOWED_AREA_LABEL,
   type Category,
+  formatPhoneForDisplay,
   isAllowedZip,
+  isValidPhone,
   type Listing,
+  normalizePhone,
 } from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { useLoadAddresses } from "../hooks/useLoadAddresses";
+import { useStore } from "../store/useStore";
 
 export function EditListing() {
   const { id } = useParams<{ id: string }>();
@@ -117,6 +123,11 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
   const [submitting, setSubmitting] = useState(false);
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [userEdited, setUserEdited] = useState(false);
+  const [sharePhone, setSharePhone] = useState(Boolean(listing.sharePhone));
+  const [phone, setPhone] = useState(listing.phone ? formatPhoneForDisplay(listing.phone) : "");
+  const setProfile = useStore((s) => s.setProfile);
+
+  const phoneInvalid = sharePhone && !isValidPhone(phone);
 
   const validateZip = useCallback((zip: string) => {
     if (zip && !isAllowedZip(zip)) {
@@ -156,6 +167,7 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
       );
       return;
     }
+    if (phoneInvalid) return;
     setSubmitting(true);
     setSubmitError(null);
 
@@ -169,11 +181,14 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
       }
 
       const catInfo = CATEGORIES.find((c) => c.name === category);
+      const normalizedPhone = sharePhone && phone ? normalizePhone(phone) : "";
 
       const payload: Record<string, unknown> = {
         category: category as string,
         description,
         estimatedValue: catInfo?.payoutLabel || "Varies",
+        sharePhone,
+        phone: normalizedPhone,
       };
 
       if (photoUrl) payload.photoUrl = photoUrl;
@@ -183,6 +198,17 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
       if (zipCode) payload.zipCode = zipCode.trim();
 
       await updateListing(accessToken, listing.listingId, payload);
+
+      // Save updated phone to profile so future listings auto-fill it.
+      if (sharePhone && normalizedPhone) {
+        try {
+          const res = await updateProfile(accessToken, { phone: normalizedPhone });
+          setProfile(res.profile);
+        } catch {
+          // Non-fatal
+        }
+      }
+
       navigate("/list");
     } catch (err) {
       setSubmitError(err instanceof Error ? err.message : "Failed to update listing");
@@ -284,6 +310,21 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
             />
           </div>
 
+          <PhoneSharingField
+            sharePhone={sharePhone}
+            phone={phone}
+            invalid={phoneInvalid}
+            showError={true}
+            onShareChange={(value) => {
+              setSharePhone(value);
+              setUserEdited(true);
+            }}
+            onPhoneChange={(value) => {
+              setPhone(value);
+              setUserEdited(true);
+            }}
+          />
+
           {zipError && (
             <div className="p-3 bg-red-50 border border-red-200 rounded-xl flex items-start gap-2">
               <AlertTriangle size={16} className="text-red-500 flex-shrink-0 mt-0.5" />
@@ -306,6 +347,7 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
               !description ||
               (photoDeleted && !photoFile) ||
               !!zipError ||
+              phoneInvalid ||
               !userEdited ||
               submitting
             }

--- a/packages/ui/src/pages/EditListing.tsx
+++ b/packages/ui/src/pages/EditListing.tsx
@@ -23,7 +23,6 @@ import {
   isAllowedZip,
   isValidPhone,
   type Listing,
-  normalizePhone,
 } from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { useLoadAddresses } from "../hooks/useLoadAddresses";
@@ -190,14 +189,14 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
       }
 
       const catInfo = CATEGORIES.find((c) => c.name === category);
-      const normalizedPhone = sharePhone && phone ? normalizePhone(phone) : "";
+      const phoneToSend = sharePhone ? phone : "";
 
       const payload: Record<string, unknown> = {
         category: category as string,
         description,
         estimatedValue: catInfo?.payoutLabel || "Varies",
         sharePhone,
-        phone: normalizedPhone,
+        phone: phoneToSend,
       };
 
       if (photoUrl) payload.photoUrl = photoUrl;
@@ -209,9 +208,9 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
       await updateListing(accessToken, listing.listingId, payload);
 
       // Save updated phone to profile so future listings auto-fill it.
-      if (sharePhone && normalizedPhone) {
+      if (sharePhone && phoneToSend) {
         try {
-          const res = await updateProfile(accessToken, { phone: normalizedPhone });
+          const res = await updateProfile(accessToken, { phone: phoneToSend });
           setProfile(res.profile);
         } catch {
           // Non-fatal

--- a/packages/ui/src/pages/EditListing.tsx
+++ b/packages/ui/src/pages/EditListing.tsx
@@ -27,6 +27,7 @@ import {
 } from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { useLoadAddresses } from "../hooks/useLoadAddresses";
+import { useLoadProfile } from "../hooks/useLoadProfile";
 import { useStore } from "../store/useStore";
 
 export function EditListing() {
@@ -100,6 +101,7 @@ export function EditListing() {
 function EditListingForm({ accessToken, listing }: { accessToken: string; listing: Listing }) {
   const navigate = useNavigate();
   const { addresses, loading: addressesLoading } = useLoadAddresses(accessToken);
+  const { profile } = useLoadProfile(accessToken);
   const [confirmDelete, setConfirmDelete] = useState(false);
   const [deleting, setDeleting] = useState(false);
 
@@ -126,6 +128,13 @@ function EditListingForm({ accessToken, listing }: { accessToken: string; listin
   const [sharePhone, setSharePhone] = useState(Boolean(listing.sharePhone));
   const [phone, setPhone] = useState(listing.phone ? formatPhoneForDisplay(listing.phone) : "");
   const setProfile = useStore((s) => s.setProfile);
+
+  // When user toggles sharing on and no phone is set yet, seed from their profile.
+  useEffect(() => {
+    if (sharePhone && !phone && profile?.phone) {
+      setPhone(formatPhoneForDisplay(profile.phone));
+    }
+  }, [sharePhone, phone, profile]);
 
   const phoneInvalid = sharePhone && !isValidPhone(phone);
 

--- a/packages/ui/src/pages/ScrapprDashboard.tsx
+++ b/packages/ui/src/pages/ScrapprDashboard.tsx
@@ -8,6 +8,7 @@ import {
   Loader2,
   Map as MapIcon,
   MapPin,
+  Phone,
   Truck,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
@@ -22,7 +23,7 @@ import {
 import { CategoryIcon } from "../components/CategoryIcon";
 import { MapView } from "../components/MapView";
 import { CATEGORIES, getCategoryDisplayName } from "../data/mockData";
-import type { Category, Listing } from "../data/types";
+import { type Category, formatPhoneForDisplay, type Listing } from "../data/types";
 import { useAuth } from "../hooks/useAuth";
 import { formatRelativeDate } from "../utils/formatDate";
 
@@ -667,10 +668,23 @@ function ClaimedCard({
             </div>
           )}
         </div>
-        <div className="flex items-center gap-1 text-xs text-gray-400 mb-3">
+        <div className="flex items-center gap-1 text-xs text-gray-400 mb-1">
           <MapPin size={12} />
           <span>{listing.address}</span>
         </div>
+        {listing.phone && (
+          <div className="flex items-center gap-1 text-xs text-emerald-600 mb-3">
+            <Phone size={12} />
+            <a
+              href={`tel:${listing.phone}`}
+              className="hover:underline"
+              data-testid="claimed-phone-link"
+            >
+              {formatPhoneForDisplay(listing.phone)}
+            </a>
+          </div>
+        )}
+        {!listing.phone && <div className="mb-3" />}
         <div className="flex gap-2">
           <button
             type="button"

--- a/packages/ui/src/store/useStore.ts
+++ b/packages/ui/src/store/useStore.ts
@@ -1,6 +1,6 @@
 import { create } from "zustand";
 import { MOCK_LISTINGS } from "../data/mockData";
-import type { Address, Listing, ListingStatus } from "../data/types";
+import type { Address, Listing, ListingStatus, UserProfile } from "../data/types";
 
 interface AppState {
   listings: Listing[];
@@ -13,6 +13,10 @@ interface AppState {
   addAddress: (address: Address) => void;
   updateAddress: (addressId: string, updates: Partial<Address>) => void;
   removeAddress: (addressId: string) => void;
+
+  profile: UserProfile | null;
+  profileLoaded: boolean;
+  setProfile: (profile: UserProfile) => void;
 }
 
 export const useStore = create<AppState>((set) => ({
@@ -54,4 +58,8 @@ export const useStore = create<AppState>((set) => ({
       }
       return { addresses: remaining };
     }),
+
+  profile: null,
+  profileLoaded: false,
+  setProfile: (profile) => set({ profile, profileLoaded: true }),
 }));

--- a/template.yaml
+++ b/template.yaml
@@ -251,6 +251,38 @@ Resources:
             Method: DELETE
             ApiId: !Ref HttpApi
 
+  GetProfileFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: get-profile.handler
+      CodeUri: packages/infra/src/lambdas/
+      Environment:
+        Variables:
+          USER_PROFILES_TABLE: !Sub "scrappr-user-profiles-${Env}"
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /profile
+            Method: GET
+            ApiId: !Ref HttpApi
+
+  UpdateProfileFunction:
+    Type: AWS::Serverless::Function
+    Properties:
+      Handler: update-profile.handler
+      CodeUri: packages/infra/src/lambdas/
+      Environment:
+        Variables:
+          USER_PROFILES_TABLE: !Sub "scrappr-user-profiles-${Env}"
+      Events:
+        Api:
+          Type: HttpApi
+          Properties:
+            Path: /profile
+            Method: PATCH
+            ApiId: !Ref HttpApi
+
   ReportErrorFunction:
     Type: AWS::Serverless::Function
     Properties:

--- a/template.yaml
+++ b/template.yaml
@@ -280,7 +280,7 @@ Resources:
           Type: HttpApi
           Properties:
             Path: /profile
-            Method: PATCH
+            Method: POST
             ApiId: !Ref HttpApi
 
   ReportErrorFunction:


### PR DESCRIPTION
## Summary

Closes #87. Listers can opt in to sharing their phone with the hauler who claims their listing. Phone stays private until claim — mirrors the existing address privacy pattern.

- **Opt-in checkbox + phone input** on Create and Edit listing forms (shared \`PhoneSharingField\` component)
- **Backend privacy boundary**: \`get-listings.mjs\` strips \`phone\` from browse responses; \`get-claimed-listings.mjs\` returns it intact so the hauler sees the number after claiming
- **Auto-fill from profile**: new \`UserProfilesTable\` + \`/profile\` GET/PATCH lambdas persist the user's last-used phone so subsequent listings prefill the field
- **Phone reveal**: \`ScrapprDashboard\` ClaimedCard renders a \`tel:\` link for the stored phone
- **Validation**: single source of truth in \`packages/shared/src/types.ts\` (\`isValidPhone\` / \`normalizePhone\`) mirrored in \`sanitize.mjs\`. Stored E.164 \`+1XXXXXXXXXX\` (US-only, Twin Cities MVP)
- Clearing the opt-in on edit forces server-side \`phone = \"\"\` even if the client omits it

## Test plan

- [ ] Preview env deploys the new \`UserProfilesTable\` and \`/profile\` routes
- [ ] As scrappee: create listing without phone → works as before
- [ ] As scrappee: create listing with phone checked + valid number → listing created
- [ ] Invalid phone (e.g. \`123\`) blocks submit; unchecking the box re-enables submit
- [ ] Return to Create Listing → phone auto-fills from profile, checkbox pre-checked
- [ ] Edit existing listing → can toggle phone on/off, server clears phone when toggled off
- [ ] As hauler on \`/haul\`: browse view shows no phone on available card (privacy check)
- [ ] As hauler: claim the listing → phone appears as a \`tel:\` link on the ClaimedCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)