### PR TITLE
ci: mask SSM secrets before exporting to GITHUB_ENV

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -38,12 +38,22 @@ jobs:
 
       - name: Load secrets from SSM
         run: |
-          echo "GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /scrappr/ci/google-client-id --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "GOOGLE_CLIENT_SECRET=$(aws ssm get-parameter --name /scrappr/ci/google-client-secret --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_GOOGLE_PLACES_API_KEY=$(aws ssm get-parameter --name /scrappr/ci/google-places-api-key --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_USER_POOL_ID=$(aws ssm get-parameter --name /scrappr/ci/vite-user-pool-id --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_USER_POOL_CLIENT_ID=$(aws ssm get-parameter --name /scrappr/ci/vite-user-pool-client-id --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_COGNITO_DOMAIN=$(aws ssm get-parameter --name /scrappr/ci/vite-cognito-domain --query Parameter.Value --output text)" >> $GITHUB_ENV
+          # Mask values as GitHub Actions secrets before exporting to $GITHUB_ENV.
+          # Without ::add-mask::, SSM values print in plaintext when the next step
+          # logs its env block.
+          load_secret() {
+            local name=$1 param=$2
+            local value
+            value=$(aws ssm get-parameter --name "$param" --with-decryption --query Parameter.Value --output text)
+            echo "::add-mask::$value"
+            echo "$name=$value" >> "$GITHUB_ENV"
+          }
+          load_secret GOOGLE_CLIENT_ID /scrappr/ci/google-client-id
+          load_secret GOOGLE_CLIENT_SECRET /scrappr/ci/google-client-secret
+          load_secret VITE_GOOGLE_PLACES_API_KEY /scrappr/ci/google-places-api-key
+          load_secret VITE_USER_POOL_ID /scrappr/ci/vite-user-pool-id
+          load_secret VITE_USER_POOL_CLIENT_ID /scrappr/ci/vite-user-pool-client-id
+          load_secret VITE_COGNITO_DOMAIN /scrappr/ci/vite-cognito-domain
 
       - name: Wait for any in-progress stack updates
         run: |
@@ -156,12 +166,22 @@ jobs:
 
       - name: Load secrets from SSM
         run: |
-          echo "GOOGLE_CLIENT_ID=$(aws ssm get-parameter --name /scrappr/ci/google-client-id --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "GOOGLE_CLIENT_SECRET=$(aws ssm get-parameter --name /scrappr/ci/google-client-secret --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_GOOGLE_PLACES_API_KEY=$(aws ssm get-parameter --name /scrappr/ci/google-places-api-key --with-decryption --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_USER_POOL_ID=$(aws ssm get-parameter --name /scrappr/ci/vite-user-pool-id --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_USER_POOL_CLIENT_ID=$(aws ssm get-parameter --name /scrappr/ci/vite-user-pool-client-id --query Parameter.Value --output text)" >> $GITHUB_ENV
-          echo "VITE_COGNITO_DOMAIN=$(aws ssm get-parameter --name /scrappr/ci/vite-cognito-domain --query Parameter.Value --output text)" >> $GITHUB_ENV
+          # Mask values as GitHub Actions secrets before exporting to $GITHUB_ENV.
+          # Without ::add-mask::, SSM values print in plaintext when the next step
+          # logs its env block.
+          load_secret() {
+            local name=$1 param=$2
+            local value
+            value=$(aws ssm get-parameter --name "$param" --with-decryption --query Parameter.Value --output text)
+            echo "::add-mask::$value"
+            echo "$name=$value" >> "$GITHUB_ENV"
+          }
+          load_secret GOOGLE_CLIENT_ID /scrappr/ci/google-client-id
+          load_secret GOOGLE_CLIENT_SECRET /scrappr/ci/google-client-secret
+          load_secret VITE_GOOGLE_PLACES_API_KEY /scrappr/ci/google-places-api-key
+          load_secret VITE_USER_POOL_ID /scrappr/ci/vite-user-pool-id
+          load_secret VITE_USER_POOL_CLIENT_ID /scrappr/ci/vite-user-pool-client-id
+          load_secret VITE_COGNITO_DOMAIN /scrappr/ci/vite-cognito-domain
 
       - name: Redeploy API stacks from previous commit
         id: api


### PR DESCRIPTION
## Summary

Stops CI from leaking SSM-sourced secrets in plaintext in Actions logs.

## The leak

The \`Load secrets from SSM\` step in \`deploy.yml\` wrote values directly to \`\$GITHUB_ENV\` using command substitution:

\`\`\`bash
echo \"GOOGLE_CLIENT_SECRET=\$(aws ssm get-parameter ...)\" >> \$GITHUB_ENV
\`\`\`

Because these values were never registered as secrets with GitHub Actions, the runner happily printed them in plaintext when the *next* step logged its \`env:\` block. In past runs, \`GOOGLE_CLIENT_SECRET\`, \`GOOGLE_CLIENT_ID\`, and \`VITE_GOOGLE_PLACES_API_KEY\` were all visible in workflow logs.

## Fix

Fetch each value into a shell local, call \`::add-mask::\` on it, then export. After \`::add-mask::\`, GitHub Actions replaces the literal value with \`***\` in all subsequent log output — including step env dumps.

Wrapped in a \`load_secret\` function to keep the list readable and avoid a 3-line incantation per secret.

Applied identically to both the \`deploy\` job and the \`rollback\` job.

## Aftermath

The previously-leaked \`GOOGLE_CLIENT_SECRET\` has already been rotated (twice) and the compromised versions deleted from the Google OAuth client. The \`VITE_GOOGLE_PLACES_API_KEY\` still needs rotating — that's tracked separately and should happen *after* this PR merges so the rotation itself doesn't leak.

## Test plan

- [ ] PR checks pass (lint, format)
- [ ] After merge, next Deploy Production run shows \`GOOGLE_CLIENT_SECRET: ***\` instead of the real value in the \`env:\` block of subsequent steps
- [ ] Verify by inspecting the \`Deploy email + alert + ...\` step logs after the run

🤖 Generated with [Claude Code](https://claude.com/claude-code)