### PR TITLE
fix: point e2e forgot-password test at correct inbox bucket

### DIFF
--- a/packages/e2e/tests/forgot-password.spec.ts
+++ b/packages/e2e/tests/forgot-password.spec.ts
@@ -8,7 +8,7 @@ import { expect, test } from "@playwright/test";
 const TEST_EMAIL = "testuser1@scrappr.trevor.fail";
 const ORIGINAL_PASSWORD = "TestPass123!";
 const TEMP_PASSWORD = "TempResetPass456!";
-const INBOX_BUCKET = "scrappr-inbox-dev";
+const INBOX_BUCKET = "scrappr-email-inbox-dev";
 const INBOX_PREFIX = "incoming/";
 const USER_POOL_ID = process.env.USER_POOL_ID || "us-east-1_N45oIsOs3";
 


### PR DESCRIPTION
## Summary

One-line fix for the broken forgot-password e2e test that's been failing every deploy since late March.

## Root cause

The bucket was renamed from \`scrappr-inbox-dev\` to \`scrappr-email-inbox-dev\` in commit \`aacca8b\` (\"Rename inbox bucket to avoid orphaned bucket conflict\"), but the e2e test still hard-coded the old name. Every subsequent deploy to main hit \`AccessDenied\` (AWS returns 403 for non-existent buckets, not 404), failed e2e, and auto-rolled-back via the rollback job.

Current authoritative bucket name lives in \`email-stack.ts\`:
\`\`\`ts
bucketName: \`scrappr-email-inbox-\${stageName}\`,
\`\`\`

## Impact

Since the rename landed, **every merge to main has been auto-rolled-back** — ~8 commits worth of changes (RequireAuth, Sign Up button, alert stack CI deploy, phone sharing, etc.). All the UI/API changes that we shipped from PRs on April 10–11 have never actually been live on prod because rollback kept winding them back.

After this merges and the deploy succeeds, all those accumulated changes will finally land at once.

## Test plan

- [ ] PR checks pass
- [ ] After merge, Deploy Production \`deploy\` job succeeds
- [ ] \`e2e\` job succeeds (the test will now be able to read the inbox bucket)
- [ ] \`rollback\` job does NOT run (because e2e passed)
- [ ] Accumulated UI changes from the last ~8 main commits are finally live on scrappr.trevor.fail

🤖 Generated with [Claude Code](https://claude.com/claude-code)