### PR TITLE
refactor: share auth page layout via AuthLayout component

### DIFF
--- a/packages/ui/src/components/AuthLayout.tsx
+++ b/packages/ui/src/components/AuthLayout.tsx
@@ -1,0 +1,23 @@
+import type { ReactNode } from "react";
+
+export function AuthLayout({
+  heading,
+  subtitle,
+  children,
+}: {
+  heading: string;
+  subtitle?: ReactNode;
+  children: ReactNode;
+}) {
+  return (
+    <div className="flex-1 flex items-center justify-center px-4 py-8">
+      <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm">
+        <h2 className={`text-xl font-bold text-gray-900 text-center ${subtitle ? "mb-2" : "mb-6"}`}>
+          {heading}
+        </h2>
+        {subtitle && <p className="text-sm text-gray-500 mb-6 text-center">{subtitle}</p>}
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/packages/ui/src/components/SignInForm.tsx
+++ b/packages/ui/src/components/SignInForm.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link } from "react-router-dom";
+import { AuthLayout } from "./AuthLayout";
 import { GoogleSignInButton } from "./GoogleSignInButton";
 
 export function SignInForm({
@@ -28,72 +29,68 @@ export function SignInForm({
   };
 
   return (
-    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
-      <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm">
-        <h2 className="text-xl font-bold text-gray-900 mb-6 text-center">Sign In to Scrappr</h2>
+    <AuthLayout heading="Sign In to Scrappr">
+      <GoogleSignInButton onClick={onGoogleSignIn} />
 
-        <GoogleSignInButton onClick={onGoogleSignIn} />
-
-        {/* Divider */}
-        <div className="flex items-center gap-3 my-6">
-          <div className="flex-1 h-px bg-gray-200" />
-          <span className="text-sm text-gray-400">or</span>
-          <div className="flex-1 h-px bg-gray-200" />
-        </div>
-
-        {/* Email/Password Form */}
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-            <input
-              type="email"
-              value={email}
-              onChange={(e) => setEmail(e.target.value)}
-              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              placeholder="you@example.com"
-              required
-            />
-          </div>
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-            <input
-              type="password"
-              value={password}
-              onChange={(e) => setPassword(e.target.value)}
-              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-              placeholder="••••••••"
-              required
-            />
-          </div>
-          {error && <p className="text-red-600 text-sm">{error}</p>}
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
-          >
-            {loading ? "Signing in..." : "Sign In"}
-          </button>
-        </form>
-
-        {/* Forgot Password & Sign Up Links */}
-        <div className="mt-6 text-center space-y-3">
-          <Link
-            to="/forgot-password"
-            className="block text-sm text-emerald-600 hover:text-emerald-700 hover:underline"
-          >
-            Forgot password?
-          </Link>
-          <p className="text-sm text-gray-500">
-            Don&apos;t have an account?{" "}
-            <Link
-              to="/sign-up"
-              className="text-emerald-600 hover:text-emerald-700 font-medium hover:underline"
-            >
-              Sign up
-            </Link>
-          </p>
-        </div>
+      {/* Divider */}
+      <div className="flex items-center gap-3 my-6">
+        <div className="flex-1 h-px bg-gray-200" />
+        <span className="text-sm text-gray-400">or</span>
+        <div className="flex-1 h-px bg-gray-200" />
       </div>
-    </div>
+
+      {/* Email/Password Form */}
+      <form onSubmit={handleSubmit} className="space-y-4">
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+          <input
+            type="email"
+            value={email}
+            onChange={(e) => setEmail(e.target.value)}
+            className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            placeholder="you@example.com"
+            required
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+          <input
+            type="password"
+            value={password}
+            onChange={(e) => setPassword(e.target.value)}
+            className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            placeholder="••••••••"
+            required
+          />
+        </div>
+        {error && <p className="text-red-600 text-sm">{error}</p>}
+        <button
+          type="submit"
+          disabled={loading}
+          className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
+        >
+          {loading ? "Signing in..." : "Sign In"}
+        </button>
+      </form>
+
+      {/* Forgot Password & Sign Up Links */}
+      <div className="mt-6 text-center space-y-3">
+        <Link
+          to="/forgot-password"
+          className="block text-sm text-emerald-600 hover:text-emerald-700 hover:underline"
+        >
+          Forgot password?
+        </Link>
+        <p className="text-sm text-gray-500">
+          Don&apos;t have an account?{" "}
+          <Link
+            to="/sign-up"
+            className="text-emerald-600 hover:text-emerald-700 font-medium hover:underline"
+          >
+            Sign up
+          </Link>
+        </p>
+      </div>
+    </AuthLayout>
   );
 }

--- a/packages/ui/src/pages/ForgotPassword.tsx
+++ b/packages/ui/src/pages/ForgotPassword.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { AuthLayout } from "../components/AuthLayout";
 import { useAuth } from "../hooks/useAuth";
 
 type Step = "request" | "confirm" | "done";
@@ -53,109 +54,106 @@ export function ForgotPassword() {
 
   if (step === "done") {
     return (
-      <div className="min-h-[60vh] flex items-center justify-center px-4">
-        <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm text-center">
+      <AuthLayout heading="Password Reset">
+        <div className="text-center">
           <div className="text-4xl mb-4">✅</div>
-          <h2 className="text-xl font-bold text-gray-900 mb-2">Password Reset</h2>
           <p className="text-sm text-gray-500 mb-6">
             Your password has been reset successfully. You can now sign in with your new password.
           </p>
           <button
             type="button"
-            onClick={() => navigate("/list")}
+            onClick={() => navigate("/sign-in")}
             className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-600 text-white font-semibold rounded-full hover:bg-emerald-700 transition-all shadow-md"
           >
             Sign In
           </button>
         </div>
-      </div>
+      </AuthLayout>
     );
   }
 
   return (
-    <div className="min-h-[60vh] flex items-center justify-center px-4">
-      <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm">
-        <h2 className="text-xl font-bold text-gray-900 mb-2 text-center">Reset Your Password</h2>
-        <p className="text-sm text-gray-500 mb-6 text-center">
-          {step === "request"
-            ? "Enter your email and we'll send you a verification code."
-            : "Enter the code we sent to your email and your new password."}
-        </p>
-
-        {step === "request" && (
-          <form onSubmit={handleRequestCode} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-              <input
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                placeholder="you@example.com"
-                required
-              />
-            </div>
-            {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
-            >
-              {loading ? "Sending..." : "Send Reset Code"}
-            </button>
-          </form>
-        )}
-
-        {step === "confirm" && (
-          <form onSubmit={handleConfirm} className="space-y-4">
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Verification Code
-              </label>
-              <input
-                type="text"
-                value={code}
-                onChange={(e) => setCode(e.target.value)}
-                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                placeholder="123456"
-                required
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-1">New Password</label>
-              <input
-                type="password"
-                value={newPassword}
-                onChange={(e) => setNewPassword(e.target.value)}
-                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                placeholder="••••••••"
-                required
-                minLength={8}
-              />
-              <p className="text-xs text-gray-400 mt-1">
-                Min 8 characters, with uppercase, lowercase, and a number.
-              </p>
-            </div>
-            {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
-            <button
-              type="submit"
-              disabled={loading}
-              className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
-            >
-              {loading ? "Resetting..." : "Reset Password"}
-            </button>
-          </form>
-        )}
-
-        <div className="mt-6 text-center">
-          <Link
-            to="/list"
-            className="text-sm text-emerald-600 hover:text-emerald-700 hover:underline"
+    <AuthLayout
+      heading="Reset Your Password"
+      subtitle={
+        step === "request"
+          ? "Enter your email and we'll send you a verification code."
+          : "Enter the code we sent to your email and your new password."
+      }
+    >
+      {step === "request" && (
+        <form onSubmit={handleRequestCode} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+            <input
+              type="email"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="you@example.com"
+              required
+            />
+          </div>
+          {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
           >
-            Back to Sign In
-          </Link>
-        </div>
+            {loading ? "Sending..." : "Send Reset Code"}
+          </button>
+        </form>
+      )}
+
+      {step === "confirm" && (
+        <form onSubmit={handleConfirm} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Verification Code
+            </label>
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="123456"
+              required
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">New Password</label>
+            <input
+              type="password"
+              value={newPassword}
+              onChange={(e) => setNewPassword(e.target.value)}
+              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="••••••••"
+              required
+              minLength={8}
+            />
+            <p className="text-xs text-gray-400 mt-1">
+              Min 8 characters, with uppercase, lowercase, and a number.
+            </p>
+          </div>
+          {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
+          >
+            {loading ? "Resetting..." : "Reset Password"}
+          </button>
+        </form>
+      )}
+
+      <div className="mt-6 text-center">
+        <Link
+          to="/sign-in"
+          className="text-sm text-emerald-600 hover:text-emerald-700 hover:underline"
+        >
+          Back to Sign In
+        </Link>
       </div>
-    </div>
+    </AuthLayout>
   );
 }

--- a/packages/ui/src/pages/SignUp.tsx
+++ b/packages/ui/src/pages/SignUp.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { AuthLayout } from "../components/AuthLayout";
 import { GoogleSignInButton } from "../components/GoogleSignInButton";
 import { useAuth } from "../hooks/useAuth";
 
@@ -54,106 +55,103 @@ export function SignUp() {
     }
   };
 
+  const heading = step === "register" ? "Create Your Account" : "Verify Your Email";
+  const subtitle =
+    step === "confirm" ? (
+      <>
+        We sent a verification code to <strong>{email}</strong>. Enter it below.
+      </>
+    ) : undefined;
+
   return (
-    <div className="min-h-[60vh] flex items-center justify-center px-4">
-      <div className="bg-white rounded-2xl shadow-lg p-8 w-full max-w-sm">
-        <h2 className="text-xl font-bold text-gray-900 mb-6 text-center">
-          {step === "register" ? "Create Your Account" : "Verify Your Email"}
-        </h2>
+    <AuthLayout heading={heading} subtitle={subtitle}>
+      {step === "register" && (
+        <>
+          <GoogleSignInButton onClick={initiateGoogleSignIn} label="Sign up with Google" />
 
-        {step === "register" && (
-          <>
-            <GoogleSignInButton onClick={initiateGoogleSignIn} label="Sign up with Google" />
+          {/* Divider */}
+          <div className="flex items-center gap-3 my-6">
+            <div className="flex-1 h-px bg-gray-200" />
+            <span className="text-sm text-gray-400">or</span>
+            <div className="flex-1 h-px bg-gray-200" />
+          </div>
 
-            {/* Divider */}
-            <div className="flex items-center gap-3 my-6">
-              <div className="flex-1 h-px bg-gray-200" />
-              <span className="text-sm text-gray-400">or</span>
-              <div className="flex-1 h-px bg-gray-200" />
+          <form onSubmit={handleRegister} className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
+              <input
+                type="email"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                placeholder="you@example.com"
+                required
+              />
             </div>
-
-            <form onSubmit={handleRegister} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Email</label>
-                <input
-                  type="email"
-                  value={email}
-                  onChange={(e) => setEmail(e.target.value)}
-                  className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                  placeholder="you@example.com"
-                  required
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
-                <input
-                  type="password"
-                  value={password}
-                  onChange={(e) => setPassword(e.target.value)}
-                  className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                  placeholder="••••••••"
-                  required
-                  minLength={8}
-                />
-                <p className="text-xs text-gray-400 mt-1">
-                  Min 8 characters, with uppercase, lowercase, and a number.
-                </p>
-              </div>
-              {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
-              <button
-                type="submit"
-                disabled={loading}
-                className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
-              >
-                {loading ? "Creating account..." : "Sign Up"}
-              </button>
-            </form>
-          </>
-        )}
-
-        {step === "confirm" && (
-          <>
-            <p className="text-sm text-gray-500 mb-6 text-center">
-              We sent a verification code to <strong>{email}</strong>. Enter it below.
-            </p>
-            <form onSubmit={handleConfirm} className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-700 mb-1">
-                  Verification Code
-                </label>
-                <input
-                  type="text"
-                  value={code}
-                  onChange={(e) => setCode(e.target.value)}
-                  className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
-                  placeholder="123456"
-                  required
-                />
-              </div>
-              {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
-              <button
-                type="submit"
-                disabled={loading}
-                className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
-              >
-                {loading ? "Verifying..." : "Verify Email"}
-              </button>
-            </form>
-          </>
-        )}
-
-        <div className="mt-6 text-center">
-          <p className="text-sm text-gray-500">
-            Already have an account?{" "}
-            <Link
-              to="/list"
-              className="text-emerald-600 hover:text-emerald-700 font-medium hover:underline"
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">Password</label>
+              <input
+                type="password"
+                value={password}
+                onChange={(e) => setPassword(e.target.value)}
+                className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                placeholder="••••••••"
+                required
+                minLength={8}
+              />
+              <p className="text-xs text-gray-400 mt-1">
+                Min 8 characters, with uppercase, lowercase, and a number.
+              </p>
+            </div>
+            {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
+            <button
+              type="submit"
+              disabled={loading}
+              className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
             >
-              Sign in
-            </Link>
-          </p>
-        </div>
+              {loading ? "Creating account..." : "Sign Up"}
+            </button>
+          </form>
+        </>
+      )}
+
+      {step === "confirm" && (
+        <form onSubmit={handleConfirm} className="space-y-4">
+          <div>
+            <label className="block text-sm font-medium text-gray-700 mb-1">
+              Verification Code
+            </label>
+            <input
+              type="text"
+              value={code}
+              onChange={(e) => setCode(e.target.value)}
+              className="w-full rounded-xl border border-gray-300 px-4 py-3 text-sm focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              placeholder="123456"
+              required
+            />
+          </div>
+          {displayError && <p className="text-red-600 text-sm">{displayError}</p>}
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full py-3 bg-emerald-600 text-white font-semibold rounded-xl hover:bg-emerald-700 transition-all disabled:opacity-40"
+          >
+            {loading ? "Verifying..." : "Verify Email"}
+          </button>
+        </form>
+      )}
+
+      <div className="mt-6 text-center">
+        <p className="text-sm text-gray-500">
+          Already have an account?{" "}
+          <Link
+            to="/sign-in"
+            className="text-emerald-600 hover:text-emerald-700 font-medium hover:underline"
+          >
+            Sign in
+          </Link>
+        </p>
       </div>
-    </div>
+    </AuthLayout>
   );
 }


### PR DESCRIPTION
## Summary

Fixes the visual inconsistency between the Sign In, Sign Up, and Forgot Password pages (Sign In was vertically centered in the full viewport; Sign Up and Forgot Password were centered in `min-h-[60vh]`, pushing their cards visibly higher on the screen) and deduplicates the card wrapper markup that was copy-pasted across all three files.

## Before

| Page | Wrapper |
|---|---|
| SignInForm | `min-h-screen bg-gray-50 flex items-center justify-center px-4` |
| SignUp | `min-h-[60vh] flex items-center justify-center px-4` |
| ForgotPassword | `min-h-[60vh] flex items-center justify-center px-4` |

Same card classes and same heading style duplicated across all three.

## After

New `AuthLayout` component used by all three pages:
- Uses `flex-1` instead of `min-h-screen` / `min-h-[60vh]` — centers inside the existing `<main className="flex-1 flex flex-col">` in `App.tsx`, so the card lands in the same place on every auth page
- Accepts optional `subtitle` prop (ReactNode, so SignUp's `<strong>{email}</strong>` still works)
- When a subtitle is present, heading uses `mb-2` instead of `mb-6`

All states covered: SignInForm, SignUp (register + confirm), ForgotPassword (request + confirm + done).

## Side fix

Updated cross-page "Sign in" / "Back to Sign In" links in SignUp and ForgotPassword from `/list` to `/sign-in`. These originally pointed to `/list` as a workaround from before a real `/sign-in` route existed; since PR #96 added `SignInPage`, they should link directly.

## Test plan

- [ ] PR checks pass
- [ ] Visual check: Sign In, Sign Up, and Forgot Password cards at the same vertical position
- [ ] SignUp register + confirm steps render correctly
- [ ] ForgotPassword request + confirm + done states render correctly
- [ ] Footer links navigate to `/sign-in`

🤖 Generated with [Claude Code](https://claude.com/claude-code)