### PR TITLE
fix: add edit icon affordance to listing cards

### DIFF
--- a/packages/ui/src/pages/ScrappeeDashboard.tsx
+++ b/packages/ui/src/pages/ScrappeeDashboard.tsx
@@ -1,4 +1,4 @@
-import { Image as ImageIcon, Loader2, LogOut, Plus } from "lucide-react";
+import { Image as ImageIcon, Loader2, LogOut, Pencil, Plus } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import { getMyListings } from "../api/client";
@@ -168,7 +168,22 @@ function ListingCard({ listing }: { listing: Listing }) {
                 {getCategoryDisplayName(listing.category)}
               </span>
             </div>
-            <StatusBadge status={listing.status} />
+            <div className="flex items-center gap-2">
+              <StatusBadge status={listing.status} />
+              {isEditable && (
+                <button
+                  className="p-1.5 rounded-lg text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 transition-colors"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    navigate(`/list/edit/${listing.listingId}`);
+                  }}
+                  aria-label="Edit listing"
+                  title="Edit listing"
+                >
+                  <Pencil size={15} />
+                </button>
+              )}
+            </div>
           </div>
           <p className="text-gray-600 text-sm mt-1 line-clamp-2">{listing.description}</p>
           <div className="flex items-center gap-4 mt-2 text-xs text-gray-400">

--- a/packages/ui/src/pages/ScrappeeDashboard.tsx
+++ b/packages/ui/src/pages/ScrappeeDashboard.tsx
@@ -171,17 +171,15 @@ function ListingCard({ listing }: { listing: Listing }) {
             <div className="flex items-center gap-2">
               <StatusBadge status={listing.status} />
               {isEditable && (
-                <button
+                <Link
+                  to={`/list/edit/${listing.listingId}`}
                   className="p-1.5 rounded-lg text-gray-400 hover:text-emerald-600 hover:bg-emerald-50 transition-colors"
-                  onClick={(e) => {
-                    e.stopPropagation();
-                    navigate(`/list/edit/${listing.listingId}`);
-                  }}
+                  onClick={(e) => e.stopPropagation()}
                   aria-label="Edit listing"
                   title="Edit listing"
                 >
                   <Pencil size={15} />
-                </button>
+                </Link>
               )}
             </div>
           </div>


### PR DESCRIPTION
Fixes #57

## Changes
- Added pencil/edit icon button to listing cards alongside the status badge
- Only shows on editable listings (status=available), matching the existing click-to-edit behaviour
- Uses `e.stopPropagation()` so button click doesn't double-fire the card's onClick
- Matches existing delete button pattern and style (lucide-react icon, hover:text-emerald-600)
- Makes the edit affordance visible so users know cards are editable

## Testing
- [ ] Edit icon appears on listing cards with status=available
- [ ] Clicking edit icon opens the edit view
- [ ] Card body click still works as before
- [ ] No visual regressions