### PR TITLE
fix: use createdAt for relative time display

### DIFF
--- a/packages/ui/src/pages/ScrappeeDashboard.tsx
+++ b/packages/ui/src/pages/ScrappeeDashboard.tsx
@@ -185,7 +185,7 @@ function ListingCard({ listing }: { listing: Listing }) {
           </div>
           <p className="text-gray-600 text-sm mt-1 line-clamp-2">{listing.description}</p>
           <div className="flex items-center gap-4 mt-2 text-xs text-gray-400">
-            <span>Posted {formatRelativeDate(listing.datePosted)}</span>
+            <span>Posted {formatRelativeDate(listing.createdAt)}</span>
             {listing.claimedBy && (
               <span className="text-yellow-600 font-medium">Hauler: {listing.claimedBy}</span>
             )}

--- a/packages/ui/src/pages/ScrapprDashboard.tsx
+++ b/packages/ui/src/pages/ScrapprDashboard.tsx
@@ -531,7 +531,7 @@ function AvailableCard({
             <CategoryIcon category={listing.category} size={14} className="text-emerald-600" />
             <span>{catInfo?.payoutLabel}</span>
           </div>
-          {listing.datePosted && <span>{formatRelativeDate(listing.datePosted)}</span>}
+          {listing.createdAt && <span>{formatRelativeDate(listing.createdAt)}</span>}
         </div>
         {error && <p className="text-xs text-red-600 mb-2">{error}</p>}
         <button


### PR DESCRIPTION
## Summary

- Use `createdAt` (full ISO timestamp) instead of `datePosted` (date-only string) for relative time display on both dashboards
- `datePosted` stores `"2026-04-14"` which parses as UTC midnight, making listings appear hours old immediately after creation

## Test plan

- [ ] Create a new listing, verify it shows "just now" instead of "X hours ago"
- [ ] Verify older listings still show correct relative times

🤖 Generated with [Claude Code](https://claude.com/claude-code)