### PR TITLE
feat: add 404 page for unmatched routes

### DIFF
--- a/packages/ui/src/App.tsx
+++ b/packages/ui/src/App.tsx
@@ -8,6 +8,7 @@ import { CreateListing } from "./pages/CreateListing";
 import { EditListing } from "./pages/EditListing";
 import { ForgotPassword } from "./pages/ForgotPassword";
 import { LandingPage } from "./pages/LandingPage";
+import { NotFound } from "./pages/NotFound";
 import { ScrappeeDashboard } from "./pages/ScrappeeDashboard";
 import { ScrapprDashboard } from "./pages/ScrapprDashboard";
 import { SignedOut } from "./pages/SignedOut";
@@ -62,6 +63,7 @@ function App() {
               <Route path="/forgot-password" element={<ForgotPassword />} />
               <Route path="/sign-up" element={<SignUp />} />
               <Route path="/signed-out" element={<SignedOut />} />
+              <Route path="*" element={<NotFound />} />
             </Routes>
           </main>
           <Footer />

--- a/packages/ui/src/pages/NotFound.tsx
+++ b/packages/ui/src/pages/NotFound.tsx
@@ -1,0 +1,25 @@
+import { Link } from "react-router-dom";
+
+export function NotFound() {
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center px-4">
+      <div className="bg-white rounded-2xl border border-gray-200 shadow-lg p-8 max-w-sm w-full text-center">
+        <img
+          src="/scrappy-mascot.png"
+          alt="Scrappy the dog mascot"
+          className="w-16 h-16 rounded-full object-cover mx-auto mb-4"
+        />
+        <h1 className="text-xl font-bold text-gray-900 mb-2">Page Not Found</h1>
+        <p className="text-sm text-gray-500 mb-6">
+          Sorry, we couldn't find the page you're looking for.
+        </p>
+        <Link
+          to="/"
+          className="inline-flex items-center gap-2 px-6 py-3 bg-emerald-600 text-white font-semibold rounded-full hover:bg-emerald-700 transition-all shadow-md"
+        >
+          Back to Home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- Adds a catch-all `*` route that renders a "Page Not Found" page
- Follows the existing card layout pattern (matches SignedOut page)
- Shows Scrappy mascot, friendly message, and "Back to Home" link

Found during QA regression testing — navigating to any unmatched route (e.g. `/totally-fake-route`) previously showed a blank page with just header/footer.

## Test plan
- [ ] Navigate to `/totally-fake-route` and verify the 404 page renders
- [ ] Verify "Back to Home" link navigates to `/`
- [ ] Verify all existing routes still work (landing, sign-in, list, haul, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)