### PR TITLE
chore: use programmatic Cognito auth for e2e tests

### DIFF
--- a/packages/e2e/auth.ts
+++ b/packages/e2e/auth.ts
@@ -1,0 +1,47 @@
+import {
+  CognitoIdentityProviderClient,
+  InitiateAuthCommand,
+} from "@aws-sdk/client-cognito-identity-provider";
+
+const CLIENT_ID = process.env.COGNITO_CLIENT_ID || "6gups5rfm8u2tvddoiqqos968g";
+
+const cognito = new CognitoIdentityProviderClient({ region: "us-east-1" });
+
+export interface CognitoTokens {
+  accessToken: string;
+  idToken: string;
+  refreshToken: string;
+  email: string;
+}
+
+/**
+ * Authenticate against Cognito using the USER_PASSWORD_AUTH flow and return
+ * the token set. Much faster than filling the sign-in form via the browser.
+ */
+export async function authenticateWithCognito(
+  email: string,
+  password: string,
+): Promise<CognitoTokens> {
+  const result = await cognito.send(
+    new InitiateAuthCommand({
+      AuthFlow: "USER_PASSWORD_AUTH",
+      ClientId: CLIENT_ID,
+      AuthParameters: {
+        USERNAME: email,
+        PASSWORD: password,
+      },
+    }),
+  );
+
+  const auth = result.AuthenticationResult;
+  if (!auth?.AccessToken || !auth?.IdToken) {
+    throw new Error(`Cognito auth failed for ${email}`);
+  }
+
+  return {
+    accessToken: auth.AccessToken,
+    idToken: auth.IdToken,
+    refreshToken: auth.RefreshToken ?? "",
+    email,
+  };
+}

--- a/packages/e2e/fixtures.ts
+++ b/packages/e2e/fixtures.ts
@@ -1,0 +1,49 @@
+import { test as base, type Page } from "@playwright/test";
+import { authenticateWithCognito, type CognitoTokens } from "./auth";
+
+export const TEST_EMAIL = "test@scrappr.dev";
+export const TEST_PASSWORD = "TestPass123!";
+export const HAULER_EMAIL = "hauler@scrappr.dev";
+export const HAULER_PASSWORD = "TestPass123!";
+
+/**
+ * Inject Cognito tokens into localStorage so the app treats the session as
+ * authenticated without going through the sign-in UI.
+ */
+async function injectAuth(page: Page, tokens: CognitoTokens): Promise<void> {
+  // Navigate to the app origin so we can write to its localStorage
+  await page.goto("/");
+  await page.evaluate((t) => {
+    localStorage.setItem("scrappr_access_token", t.accessToken);
+    localStorage.setItem("scrappr_id_token", t.idToken);
+    localStorage.setItem("scrappr_refresh_token", t.refreshToken);
+    localStorage.setItem("scrappr_email", t.email);
+    localStorage.setItem("scrappr_auth_source", "oauth");
+  }, tokens);
+}
+
+type AuthFixtures = {
+  /** Page already signed in as the scrappee test account */
+  authedPage: Page;
+  /** Sign in as a specific user and return the page (navigated to "/") */
+  signInAs: (email: string, password: string) => Promise<Page>;
+};
+
+export const test = base.extend<AuthFixtures>({
+  authedPage: async ({ page }, use) => {
+    const tokens = await authenticateWithCognito(TEST_EMAIL, TEST_PASSWORD);
+    await injectAuth(page, tokens);
+    await use(page);
+  },
+
+  signInAs: async ({ page }, use) => {
+    const fn = async (email: string, password: string) => {
+      const tokens = await authenticateWithCognito(email, password);
+      await injectAuth(page, tokens);
+      return page;
+    };
+    await use(fn);
+  },
+});
+
+export { expect } from "@playwright/test";

--- a/packages/e2e/tests/hauler.spec.ts
+++ b/packages/e2e/tests/hauler.spec.ts
@@ -1,29 +1,17 @@
 import path from "node:path";
-import { expect, test } from "@playwright/test";
-
-// Scrappee account — creates listings for pickup
-const SCRAPPEE_EMAIL = "test@scrappr.dev";
-const SCRAPPEE_PASSWORD = "TestPass123!";
-
-// Hauler account — browses and claims listings
-// Must be pre-provisioned in the shared Cognito dev pool
-const HAULER_EMAIL = "hauler@scrappr.dev";
-const HAULER_PASSWORD = "TestPass123!";
+import { expect, HAULER_EMAIL, HAULER_PASSWORD, TEST_EMAIL, test } from "../fixtures";
 
 // Real address in St. Louis Park, MN (zip 55416) — within Scrappr's service area
 const ADDRESS_QUERY = "5005 Minnetonka Blvd St Louis Park";
 
-test("scrappee creates listing, hauler claims and marks picked up", async ({ page }) => {
+test("scrappee creates listing, hauler claims and marks picked up", async ({ signInAs }) => {
   // Unique description so we can reliably find this listing in the hauler view
   const testDescription = `E2E hauler test - aluminum scrap ${Date.now()}`;
 
   // ── Step 1: Sign in as scrappee and create a listing ──────────────────────
 
+  const page = await signInAs(TEST_EMAIL, "TestPass123!");
   await page.goto("/list");
-  await expect(page.getByText("Sign In to Scrappr")).toBeVisible();
-  await page.getByPlaceholder("you@example.com").fill(SCRAPPEE_EMAIL);
-  await page.getByPlaceholder("••••••••").fill(SCRAPPEE_PASSWORD);
-  await page.getByRole("button", { name: "Sign In", exact: true }).click();
   await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
 
   await page.getByRole("link", { name: "New Listing" }).click();
@@ -68,18 +56,13 @@ test("scrappee creates listing, hauler claims and marks picked up", async ({ pag
   await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
   await expect(page.getByText(testDescription).first()).toBeVisible({ timeout: 10_000 });
 
-  // ── Step 2: Sign out ───────────────────────────────────────────────────────
+  // ── Step 2: Sign out and sign in as hauler ────────────────────────────────
 
   await page.goto("/signed-out");
   await expect(page.getByText("You've been signed out")).toBeVisible({ timeout: 10_000 });
 
-  // ── Step 3: Sign in as hauler and browse available listings ───────────────
-
+  await signInAs(HAULER_EMAIL, HAULER_PASSWORD);
   await page.goto("/haul");
-  await expect(page.getByText("Sign In to Scrappr")).toBeVisible();
-  await page.getByPlaceholder("you@example.com").fill(HAULER_EMAIL);
-  await page.getByPlaceholder("••••••••").fill(HAULER_PASSWORD);
-  await page.getByRole("button", { name: "Sign In", exact: true }).click();
   await expect(page.getByText("Hauler Dashboard")).toBeVisible({ timeout: 15_000 });
 
   // Wait for listings to load (spinner disappears)

--- a/packages/e2e/tests/listing-creation.spec.ts
+++ b/packages/e2e/tests/listing-creation.spec.ts
@@ -1,24 +1,16 @@
 import path from "node:path";
-import { expect, test } from "@playwright/test";
-
-const TEST_EMAIL = "test@scrappr.dev";
-const TEST_PASSWORD = "TestPass123!";
+import { expect, test } from "../fixtures";
 
 // Real address in St. Louis Park, MN (zip 55416) — within Scrappr's service area
 const ADDRESS_QUERY = "5005 Minnetonka Blvd St Louis Park";
 
 test.describe("Listing Creation Flow", () => {
-  test.beforeEach(async ({ page }) => {
+  test.beforeEach(async ({ authedPage: page }) => {
     await page.goto("/list");
-    await expect(page.getByText("Sign In to Scrappr")).toBeVisible();
-    await page.getByPlaceholder("you@example.com").fill(TEST_EMAIL);
-    await page.getByPlaceholder("••••••••").fill(TEST_PASSWORD);
-    await page.getByRole("button", { name: "Sign In", exact: true }).click();
     await expect(page.getByText("Your Listings")).toBeVisible({ timeout: 15_000 });
-    await expect(page.getByText(`Signed in as ${TEST_EMAIL}`)).toBeVisible();
   });
 
-  test("create listing with photo, see it in My Listings", async ({ page }) => {
+  test("create listing with photo, see it in My Listings", async ({ authedPage: page }) => {
     // 1. Navigate to New Listing page
     await page.getByRole("link", { name: "New Listing" }).click();
     await expect(page.getByText("Create a New Scrap Metal Listing")).toBeVisible();
@@ -68,7 +60,9 @@ test.describe("Listing Creation Flow", () => {
     await expect(page.getByAltText("copper").first()).toBeVisible();
   });
 
-  test("phone sharing: checkbox gates input, invalid number blocks submit", async ({ page }) => {
+  test("phone sharing: checkbox gates input, invalid number blocks submit", async ({
+    authedPage: page,
+  }) => {
     await page.getByRole("link", { name: "New Listing" }).click();
     await expect(page.getByText("Create a New Scrap Metal Listing")).toBeVisible();
 
@@ -113,7 +107,7 @@ test.describe("Listing Creation Flow", () => {
     await expect(page.getByTestId("submit-listing-btn")).toBeEnabled();
   });
 
-  test("drag-and-drop photo upload shows preview", async ({ page }) => {
+  test("drag-and-drop photo upload shows preview", async ({ authedPage: page }) => {
     // 1. Navigate to New Listing page
     await page.getByRole("link", { name: "New Listing" }).click();
     await expect(page.getByText("Create a New Scrap Metal Listing")).toBeVisible();

--- a/packages/shared/src/types.ts
+++ b/packages/shared/src/types.ts
@@ -88,6 +88,7 @@ export interface Listing {
   address: string;
   status: ListingStatus;
   datePosted: string;
+  createdAt?: string;
   claimedBy?: string;
   claimedAt?: string;
   estimatedValue: string;


### PR DESCRIPTION
## Summary
- Add `auth.ts` helper that authenticates via Cognito `InitiateAuth` SDK call (USER_PASSWORD_AUTH flow) instead of filling the sign-in form in the browser
- Add `fixtures.ts` with custom Playwright fixtures: `authedPage` (pre-authenticated as scrappee) and `signInAs(email, password)` (programmatic login for any account)
- Update `listing-creation.spec.ts` and `hauler.spec.ts` to use the new fixtures
- `forgot-password.spec.ts` unchanged — still uses UI login since it tests the auth flow itself

## Test plan
- [ ] Run `yarn test` in `packages/e2e` locally — all three spec files should pass
- [ ] Verify listing-creation and hauler tests no longer show the sign-in form
- [ ] Verify forgot-password test still exercises the UI sign-in flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)